### PR TITLE
fix: mobile hamburger menu — remove backdrop-filter on mobile

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -65,13 +65,22 @@ body {
 
 /* Nav */
 .VPNav {
-  background: rgba(255, 255, 255, 0.85) !important;
-  backdrop-filter: blur(16px) saturate(180%);
+  background: rgba(255, 255, 255, 0.95);
   border-bottom: 1px solid var(--vp-c-divider);
   transition: background 0.3s, border-color 0.3s;
 }
 .dark .VPNav {
-  background: rgba(11, 15, 19, 0.85) !important;
+  background: rgba(11, 15, 19, 0.95);
+}
+
+@media (min-width: 960px) {
+  .VPNav {
+    background: rgba(255, 255, 255, 0.85) !important;
+    backdrop-filter: blur(16px) saturate(180%);
+  }
+  .dark .VPNav {
+    background: rgba(11, 15, 19, 0.85) !important;
+  }
 }
 
 .VPNav.scrolled {


### PR DESCRIPTION
The `backdrop-filter: blur()` on `.VPNav` creates a new CSS containing block. On mobile, where `.VPNav` is `position: relative`, this causes the `VPNavScreen` (`position: fixed`) child to be clipped/hidden instead of overlaying the full screen.

Fix: Only apply `backdrop-filter` on desktop (`min-width: 960px`) where `.VPNav` is already `position: fixed`. Mobile uses a solid semi-transparent background instead.