### PR TITLE
fix: left-align code panel on mobile

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -372,6 +372,7 @@ function formatDate(date: string): string {
 
 /* ── Code Panel ───────────────────────────────────────── */
 .code-panel {
+  text-align: left;
   border-radius: 16px;
   background: rgba(255,255,255,0.05);
   border: 1px solid rgba(255,255,255,0.08);


### PR DESCRIPTION
Source code is always left-aligned. The mobile hero `text-align: center` was cascading into the code panel.