### PR TITLE
fix: content gaps, shared styles, dead links, UX improvements

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   title: 'Relaton',
   description: 'The premier bibliographic data model for standards and technical documents',
   lang: 'en-US',
-  ignoreDeadLinks: true,
+  ignoreDeadLinks: false,
 
   head: [
     ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
@@ -15,7 +15,7 @@ export default defineConfig({
     ['link', { rel: 'shortcut icon', href: '/favicon.ico' }],
     ['link', { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' }],
     ['link', { rel: 'manifest', href: '/site.webmanifest' }],
-    ['meta', { name: 'theme-color', content: '#1F6CF0' }],
+    ['meta', { name: 'theme-color', content: '#1F6CF1' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: 'Relaton' }],
   ],
@@ -25,6 +25,7 @@ export default defineConfig({
     siteTitle: 'Relaton',
 
     nav: [
+      { text: 'Get Started', link: '/get-started' },
       {
         text: 'Model',
         items: [

--- a/.vitepress/data/home.ts
+++ b/.vitepress/data/home.ts
@@ -69,12 +69,12 @@ export const homeData: HomeData = {
     titleLine2: 'Bibliographic',
     titleLine3: 'Data Model',
     subtitle:
-      'An interoperable, machine-readable data model for citations — created by the authors of ISO 690:2021, trusted by IETF, BIPM, OIML, and 25+ standards organizations.',
+      'An interoperable, machine-readable data model for citations — created by the authors of ISO 690:2021, trusted by IETF, BIPM, OIML, and 28 standards organizations.',
     primaryAction: { label: 'Explore the Model', href: '/model/' },
-    secondaryAction: { label: 'Get Started', href: '/software/' },
+    secondaryAction: { label: 'Get Started', href: '/get-started/' },
   },
 
-  stats: { orgs: 25, rels: 60, gems: 30 },
+  stats: { orgs: 28, rels: 60, gems: 33 },
 
   codeTabs: [
     { id: 'yaml', label: 'YAML' },
@@ -162,7 +162,7 @@ edition:: 2`,
     },
     {
       title: 'Auto-Fetch by PubID',
-      desc: 'Provide a publication identifier and Relaton retrieves structured metadata from 27+ SDO datasets — no manual citation maintenance.',
+      desc: 'Provide a publication identifier and Relaton retrieves structured metadata from 29 SDO datasets — no manual citation maintenance.',
       icon: '<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
       iconClass: 'icon-aqua',
     },
@@ -178,23 +178,23 @@ edition:: 2`,
     { number: '01', title: 'ISO 690', desc: 'The international standard for bibliographic references and citations — Relaton is its machine-readable implementation.', link: '/model/iso-690/', accentClass: 'layer-standard' },
     { number: '02', title: 'Information Model', desc: 'BibliographicItem + 14 entities, 60+ relation types — a comprehensive data model covering all ISO 690 data elements.', link: '/model/', accentClass: 'layer-model' },
     { number: '03', title: 'Serializations', desc: 'YAML, XML, BibTeX, AsciiBib, and JSON-LD — the same data in five formats, suited to different workflows.', link: '/model/serializations', accentClass: 'layer-serial' },
-    { number: '04', title: 'Auto-Fetch', desc: '27 flavor gems retrieve metadata from SDO datasets by publication identifier — no manual citation maintenance.', link: '/flavors/', accentClass: 'layer-fetch' },
+    { number: '04', title: 'Auto-Fetch', desc: '29 flavor gems retrieve metadata from SDO datasets by publication identifier — no manual citation maintenance.', link: '/flavors/', accentClass: 'layer-fetch' },
     { number: '05', title: 'Rendering', desc: 'Formatted citations in ISO 690, APA, MLA, and custom styles — beyond what BibTeX or CSL can express.', link: '/specs/relaton-render', accentClass: 'layer-render' },
   ],
 
   orgsSection: {
     title: 'Supported Standards Organizations',
-    subtitle: '28 organizations across international, regional, national, and identifier bodies.',
+    subtitle: '26 organizations and 2 identifier systems across international, regional, national, and industry bodies.',
   },
 
   ecosystemSection: {
     title: 'Software Ecosystem',
-    subtitle: '32 Ruby gems covering core libraries, CLI tools, and 29 flavor-specific data retrievers.',
+    subtitle: '33 Ruby gems covering core libraries, CLI tools, and 29 flavor-specific data retrievers.',
   },
 
   ecosystem: [
     { label: 'Core Libraries', count: '2', desc: 'relaton and relaton-bib — the foundation', accentClass: 'accent-blue' },
-    { label: 'CLI Tools', count: '1', desc: 'relaton-cli — build, fetch, convert', accentClass: 'accent-aqua' },
+    { label: 'CLI Tools', count: '2', desc: 'relaton-cli and relaton-render — fetch, convert, cite', accentClass: 'accent-aqua' },
     { label: 'Flavor Gems', count: '29', desc: 'One per standards organization', accentClass: 'accent-green' },
   ],
 

--- a/.vitepress/theme/components/FlavorGrid.vue
+++ b/.vitepress/theme/components/FlavorGrid.vue
@@ -7,6 +7,7 @@
           v-model="search"
           type="text"
           placeholder="Search organizations…"
+          aria-label="Search organizations"
           class="search-input"
         />
       </div>
@@ -224,22 +225,6 @@ const filteredFlavors = computed(() => {
   color: #1F6CF1;
   font-family: 'Outfit', sans-serif;
 }
-
-.badge {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 2px 7px;
-  border-radius: 4px;
-}
-.badge--international { background: rgba(31,108,241,0.08); color: #1F6CF1; }
-.badge--regional { background: rgba(234,179,8,0.08); color: #B45309; }
-.badge--national { background: rgba(33,193,151,0.08); color: #059669; }
-.badge--industry { background: rgba(249,115,22,0.08); color: #EA580C; }
-.badge--identifier { background: rgba(139,92,246,0.08); color: #7C3AED; }
-.badge--other { background: rgba(107,114,128,0.08); color: #6B7280; }
 
 .flavor-label {
   font-size: 16px;

--- a/.vitepress/theme/components/FlavorPage.vue
+++ b/.vitepress/theme/components/FlavorPage.vue
@@ -36,7 +36,7 @@
       <div class="hero-glow hero-glow--2"></div>
     </div>
 
-    <div v-if="content" class="flavor-content" v-html="content"></div>
+    <div v-if="content" class="rendered-content" v-html="content"></div>
     <div v-else class="flavor-empty">
       <svg width="40" height="40" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9z"/></svg>
       <p>Citation guide content is not yet available for this organization.</p>
@@ -58,10 +58,17 @@
           <span class="install-prefix">$</span>
           <code>gem install {{ gemName }}</code>
           <button class="copy-btn" @click="copyInstall" title="Copy">
-            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            <template v-if="!copied">
+              <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            </template>
+            <span v-else class="copy-feedback">Copied!</span>
           </button>
         </div>
         <div class="software-links">
+          <a :href="`/software/${flavor.gem}`" class="software-link">
+            <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
+            Software Details
+          </a>
           <a :href="flavor.repoUrl" target="_blank" rel="noopener noreferrer" class="software-link">
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
             GitHub
@@ -80,7 +87,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 import type { Flavor } from '../../data/types'
 import { categoryLabel } from '../../data/categories'
 import { flavorExtensions } from '../../data/flavor-extensions'
@@ -91,9 +98,14 @@ const props = defineProps<{ flavor: Flavor; content?: string }>()
 const gemName = computed(() => props.flavor?.gem || '')
 const rubygemsUrl = computed(() => `https://rubygems.org/gems/${gemName.value}`)
 const extensionData = computed(() => flavorExtensions[props.flavor?.id])
+const copied = ref(false)
+let copyTimer: ReturnType<typeof setTimeout>
 
 async function copyInstall() {
   await navigator.clipboard.writeText(`gem install ${gemName.value}`)
+  copied.value = true
+  clearTimeout(copyTimer)
+  copyTimer = setTimeout(() => { copied.value = false }, 1500)
 }
 </script>
 
@@ -162,22 +174,6 @@ async function copyInstall() {
   background: radial-gradient(circle, rgba(33,193,151,0.05) 0%, transparent 70%);
 }
 
-.badge {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 3px 9px;
-  border-radius: 4px;
-}
-.badge--international { background: rgba(31,108,241,0.08); color: #1F6CF1; }
-.badge--regional { background: rgba(234,179,8,0.08); color: #B45309; }
-.badge--national { background: rgba(33,193,151,0.08); color: #059669; }
-.badge--industry { background: rgba(249,115,22,0.08); color: #EA580C; }
-.badge--identifier { background: rgba(139,92,246,0.08); color: #7C3AED; }
-.badge--other { background: rgba(107,114,128,0.08); color: #6B7280; }
-
 .flavor-title {
   font-size: 36px;
   font-weight: 700;
@@ -218,65 +214,6 @@ async function copyInstall() {
 .source-link svg {
   flex-shrink: 0;
   opacity: 0.7;
-}
-
-.flavor-content {
-  line-height: 1.7;
-}
-.flavor-content :deep(h2) {
-  margin-top: 48px;
-  margin-bottom: 16px;
-  font-size: 24px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--vp-c-divider);
-}
-.flavor-content :deep(h3) {
-  margin-top: 32px;
-  margin-bottom: 12px;
-  font-size: 18px;
-  font-weight: 600;
-}
-.flavor-content :deep(table) {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 16px 0;
-  font-size: 14px;
-}
-.flavor-content :deep(th),
-.flavor-content :deep(td) {
-  padding: 10px 14px;
-  border: 1px solid var(--vp-c-divider);
-  text-align: left;
-}
-.flavor-content :deep(th) {
-  background: var(--vp-c-bg-soft);
-  font-weight: 600;
-  font-size: 13px;
-}
-.flavor-content :deep(code) {
-  background: var(--vp-c-bg-soft);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.88em;
-}
-.flavor-content :deep(pre) {
-  background: var(--vp-c-bg-soft);
-  padding: 16px 20px;
-  border-radius: 10px;
-  overflow-x: auto;
-  border: 1px solid var(--vp-c-divider);
-}
-.flavor-content :deep(pre code) {
-  background: none;
-  padding: 0;
-}
-.flavor-content :deep(blockquote) {
-  border-left: 3px solid #1F6CF1;
-  padding-left: 16px;
-  color: var(--vp-c-text-2);
-  margin: 16px 0;
 }
 
 .flavor-empty {
@@ -406,5 +343,10 @@ async function copyInstall() {
   .flavor-hero { padding: 32px 0 24px; }
   .flavor-logo { width: 44px; height: 44px; }
   .flavor-logo-placeholder { width: 44px; height: 44px; font-size: 18px; }
+}
+.copy-feedback {
+  font-size: 11px;
+  color: #059669;
+  font-weight: 600;
 }
 </style>

--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -372,6 +372,7 @@ function formatDate(date: string): string {
 
 /* ── Code Panel ───────────────────────────────────────── */
 .code-panel {
+  text-align: left;
   border-radius: 16px;
   background: rgba(255,255,255,0.05);
   border: 1px solid rgba(255,255,255,0.08);

--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -104,7 +104,21 @@
           <h2 class="section-title">{{ d.orgsSection.title }}</h2>
           <p class="section-subtitle">{{ d.orgsSection.subtitle }}</p>
         </div>
-        <FlavorGrid />
+        <div class="org-marquee">
+          <div class="org-marquee-track">
+            <a v-for="flavor in orgLogos" :key="flavor.id" :href="`/flavors/${flavor.id}`" class="org-logo-card" :title="flavor.fullName">
+              <img v-if="flavor.logo" :src="flavor.logo" :alt="flavor.label" class="org-logo-img" />
+              <span v-else class="org-logo-placeholder">{{ flavor.label }}</span>
+            </a>
+            <a v-for="flavor in orgLogos" :key="'dup-' + flavor.id" :href="`/flavors/${flavor.id}`" class="org-logo-card" :title="flavor.fullName">
+              <img v-if="flavor.logo" :src="flavor.logo" :alt="flavor.label" class="org-logo-img" aria-hidden="true" />
+              <span v-else class="org-logo-placeholder" aria-hidden="true">{{ flavor.label }}</span>
+            </a>
+          </div>
+        </div>
+        <div class="section-cta">
+          <a href="/flavors/" class="link-arrow">View all 28 flavors</a>
+        </div>
       </div>
     </section>
 
@@ -177,6 +191,9 @@
 import { ref, computed, onMounted } from 'vue'
 import { data as posts } from '../../posts.data'
 import { homeData as d } from '../../data/home'
+import { flavors } from '../../data/flavors'
+
+const orgLogos = computed(() => flavors.filter(f => f.category !== 'identifier'))
 
 // Count-up animation
 const statsRef = ref<HTMLElement>()
@@ -746,5 +763,54 @@ function formatDate(date: string): string {
   .code-body { padding: 12px 14px; max-height: 200px; }
   .code-body code { font-size: 11px; line-height: 1.5; }
   .layer-title { min-width: 0; }
+}
+
+.org-marquee {
+  overflow: hidden;
+  mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+  -webkit-mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+  margin: 0 -24px;
+  padding: 16px 0;
+}
+.org-marquee-track {
+  display: flex;
+  gap: 16px;
+  width: max-content;
+  animation: marquee-scroll 40s linear infinite;
+}
+.org-marquee-track:hover { animation-play-state: paused; }
+@keyframes marquee-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.org-logo-card {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 120px;
+  height: 64px;
+  border-radius: 10px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg);
+  padding: 12px 16px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  text-decoration: none;
+}
+.org-logo-card:hover {
+  border-color: rgba(31, 108, 241, 0.3);
+  box-shadow: 0 2px 8px rgba(31, 108, 241, 0.08);
+}
+.org-logo-img {
+  max-width: 80px;
+  max-height: 36px;
+  object-fit: contain;
+}
+.org-logo-placeholder {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  text-align: center;
+  line-height: 1.2;
 }
 </style>

--- a/.vitepress/theme/components/SoftwareGrid.vue
+++ b/.vitepress/theme/components/SoftwareGrid.vue
@@ -7,6 +7,7 @@
           v-model="search"
           type="text"
           placeholder="Search gems…"
+          aria-label="Search gems"
           class="search-input"
         />
       </div>
@@ -159,16 +160,6 @@ const filteredGems = computed(() => {
   font-family: var(--vp-font-family-mono, monospace);
   color: var(--vp-c-text-1);
 }
-
-.badge {
-  font-size: 10px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 0.04em;
-  padding: 2px 7px; border-radius: 4px;
-  flex-shrink: 0;
-}
-.badge--core { background: rgba(31,108,241,0.08); color: #1F6CF1; }
-.badge--tool { background: rgba(33,193,151,0.08); color: #059669; }
-.badge--flavor { background: rgba(107,114,128,0.08); color: #6B7280; }
 
 .gem-desc {
   font-size: 13px; line-height: 1.5;

--- a/.vitepress/theme/components/SoftwarePage.vue
+++ b/.vitepress/theme/components/SoftwarePage.vue
@@ -31,7 +31,10 @@
         <span class="sp-code-prompt">$</span>
         <code>gem install {{ gem.name }}</code>
         <button class="sp-copy" @click="copy(`gem install ${gem.name}`)" title="Copy">
-          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          <template v-if="!copied">
+            <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+          </template>
+          <span v-else class="sp-copy-feedback">Copied!</span>
         </button>
       </div>
     </section>
@@ -47,7 +50,7 @@
     </section>
 
     <section v-if="renderedContent" class="sp-section">
-      <div class="sp-content" v-html="renderedContent"></div>
+      <div class="rendered-content" v-html="renderedContent"></div>
     </section>
 
     <section class="sp-section">
@@ -83,6 +86,10 @@
         </div>
       </a>
     </section>
+  </div>
+  <div v-else class="sp-not-found">
+    <p>Software gem not found.</p>
+    <a href="/software/" class="sp-back-link">Browse all gems</a>
   </div>
 </template>
 
@@ -133,8 +140,14 @@ onMounted(async () => {
   }
 })
 
+const copied = ref(false)
+let copyTimer: ReturnType<typeof setTimeout>
+
 async function copy(text: string) {
   await navigator.clipboard.writeText(text)
+  copied.value = true
+  clearTimeout(copyTimer)
+  copyTimer = setTimeout(() => { copied.value = false }, 1500)
 }
 </script>
 
@@ -203,20 +216,6 @@ async function copy(text: string) {
   color: #1F6CF1;
   background: rgba(31,108,241,0.04);
 }
-
-.badge {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 3px 9px;
-  border-radius: 4px;
-  margin-bottom: 12px;
-}
-.badge--core { background: rgba(31,108,241,0.08); color: #1F6CF1; }
-.badge--tool { background: rgba(33,193,151,0.08); color: #059669; }
-.badge--flavor { background: rgba(107,114,128,0.08); color: #6B7280; }
 
 .sp-title {
   font-size: 36px;
@@ -388,60 +387,21 @@ async function copy(text: string) {
   .sp-link-grid { grid-template-columns: 1fr; }
 }
 
-.sp-content { line-height: 1.7; }
-.sp-content :deep(h2) {
-  margin-top: 48px;
-  margin-bottom: 16px;
-  font-size: 24px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--vp-c-divider);
-}
-.sp-content :deep(h3) {
-  margin-top: 32px;
-  margin-bottom: 12px;
-  font-size: 18px;
+.sp-hero .badge { margin-bottom: 12px; }
+
+.sp-copy-feedback {
+  font-size: 11px;
+  color: #059669;
   font-weight: 600;
 }
-.sp-content :deep(table) {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 16px 0;
-  font-size: 14px;
+.sp-not-found {
+  text-align: center;
+  padding: 96px 24px;
+  color: var(--vp-c-text-3);
 }
-.sp-content :deep(th),
-.sp-content :deep(td) {
-  padding: 10px 14px;
-  border: 1px solid var(--vp-c-divider);
-  text-align: left;
-}
-.sp-content :deep(th) {
-  background: var(--vp-c-bg-soft);
-  font-weight: 600;
-  font-size: 13px;
-}
-.sp-content :deep(code) {
-  background: var(--vp-c-bg-soft);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.88em;
-}
-.sp-content :deep(pre) {
-  background: var(--vp-c-bg-soft);
-  padding: 16px 20px;
-  border-radius: 10px;
-  overflow-x: auto;
-  border: 1px solid var(--vp-c-divider);
-}
-.sp-content :deep(pre code) {
-  background: none;
-  padding: 0;
-}
-.sp-content :deep(blockquote) {
-  border-left: 3px solid #1F6CF1;
-  padding-left: 16px;
-  color: var(--vp-c-text-2);
-  margin: 16px 0;
+.sp-back-link {
+  color: #1F6CF1;
+  text-decoration: none;
+  font-weight: 500;
 }
 </style>

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -472,8 +472,90 @@ body {
 }
 
 /* ==========================================================================
-   8. Print Styles
+   8. Shared Component Styles — badges, rendered markdown content
    ========================================================================== */
+
+.badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+/* Flavor categories */
+.badge--international { background: rgba(31,108,241,0.08); color: #1F6CF1; }
+.badge--regional      { background: rgba(234,179,8,0.08);  color: #B45309; }
+.badge--national      { background: rgba(33,193,151,0.08); color: #059669; }
+.badge--industry      { background: rgba(249,115,22,0.08); color: #EA580C; }
+.badge--identifier    { background: rgba(139,92,246,0.08); color: #7C3AED; }
+.badge--other         { background: rgba(107,114,128,0.08); color: #6B7280; }
+
+/* Software categories */
+.badge--core   { background: rgba(31,108,241,0.08); color: #1F6CF1; }
+.badge--tool   { background: rgba(33,193,151,0.08); color: #059669; }
+.badge--flavor { background: rgba(107,114,128,0.08); color: #6B7280; }
+
+/* Rendered markdown content (used by FlavorPage and SoftwarePage) */
+.rendered-content { line-height: 1.7; }
+.rendered-content h2 {
+  margin-top: 48px;
+  margin-bottom: 16px;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+.rendered-content h3 {
+  margin-top: 32px;
+  margin-bottom: 12px;
+  font-size: 18px;
+  font-weight: 600;
+}
+.rendered-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 14px;
+}
+.rendered-content th,
+.rendered-content td {
+  padding: 10px 14px;
+  border: 1px solid var(--vp-c-divider);
+  text-align: left;
+}
+.rendered-content th {
+  background: var(--vp-c-bg-soft);
+  font-weight: 600;
+  font-size: 13px;
+}
+.rendered-content code {
+  background: var(--vp-c-bg-soft);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.88em;
+}
+.rendered-content pre {
+  background: var(--vp-c-bg-soft);
+  padding: 16px 20px;
+  border-radius: 10px;
+  overflow-x: auto;
+  border: 1px solid var(--vp-c-divider);
+}
+.rendered-content pre code {
+  background: none;
+  padding: 0;
+}
+.rendered-content blockquote {
+  border-left: 3px solid #1F6CF1;
+  padding-left: 16px;
+  color: var(--vp-c-text-2);
+  margin: 16px 0;
+}
 
 @media print {
   header, footer, button { display: none !important; }

--- a/about.md
+++ b/about.md
@@ -59,7 +59,7 @@ Relaton spans five distinct layers:
 | **ISO&nbsp;690** | The international standard defining the conceptual framework for bibliographic references |
 | **Information Model** | Relaton's BibliographicItem with 14&nbsp;entities, 60+&nbsp;relation types, and 28+&nbsp;organization flavors |
 | **Serializations** | YAML, XML, BibTeX, AsciiBib, and JSON-LD interchange formats |
-| **Auto-Fetch** | Flavor gems that retrieve metadata from 27+ SDO datasets by publication identifier alone |
+| **Auto-Fetch** | Flavor gems that retrieve metadata from 28+ SDO datasets by publication identifier alone |
 | **Rendering** | Formatted citations in ISO&nbsp;690, APA, MLA, and custom styles via relaton-render |
 
 [Explore the model &rarr;](/model/)
@@ -93,7 +93,7 @@ Relaton's flavor architecture enables **automatic retrieval** of bibliographic m
 2. Queries the organization's dataset
 3. Returns a fully structured BibliographicItem
 
-This eliminates the need to manually maintain bibliographic citations. The system maintains indexed datasets covering all 27+ supported organizations.
+This eliminates the need to manually maintain bibliographic citations. The system maintains indexed datasets covering all 28 supported organizations.
 
 [View supported organizations &rarr;](/flavors/)
 

--- a/api/index.md
+++ b/api/index.md
@@ -1,12 +1,70 @@
 ---
 layout: page
 outline: false
-title: Try the Relaton API
+title: Relaton API
 ---
 
 <div class="page-header">
-<h1>Try the Relaton API</h1>
-<p class="page-subtitle">Fetch bibliographic data for any standard document directly in your browser.</p>
+<h1>Relaton API</h1>
+<p class="page-subtitle">Fetch structured bibliographic data for standards documents via HTTP.</p>
 </div>
+
+## About the API
+
+The Relaton API provides HTTP access to the same bibliographic data that the Ruby gems fetch locally. Given a publication identifier (e.g., `ISO 690:2010`, `RFC 8446`), it returns a structured XML record with complete metadata — title, contributors, dates, identifiers, relations, and flavor-specific extensions.
+
+The API is read-only and requires no authentication.
+
+## Endpoint
+
+```
+GET https://api.relaton.org/api/v1/bibliography
+```
+
+## Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `q` | string (required) | The publication identifier to look up (e.g., `ISO 690:2010`, `RFC 8446`, `ITU-T G.989.2`) |
+| `all_parts` | boolean | If `true`, fetches all parts of a multi-part standard (default: `false`) |
+| `keep_year` | boolean | If `true`, keeps the year in the identifier even when a newer edition exists (default: `false`) |
+
+## Response Format
+
+The API returns Relaton XML — a structured bibliographic record following the [Relaton XML schema](/model/serializations). Example response for `ISO 690:2010`:
+
+```xml
+<bibitem type="standard" id="ISO690-2010">
+  <title>Information and documentation — Guidelines for
+    bibliographic references and citations to information resources</title>
+  <docidentifier type="ISO">ISO 690:2010</docidentifier>
+  <date type="published">
+    <on>2010</on>
+  </date>
+  <contributor>
+    <role type="publisher"/>
+    <organization>
+      <name>International Organization for Standardization</name>
+    </organization>
+  </contributor>
+  <edition>2</edition>
+</bibitem>
+```
+
+## Supported Organizations
+
+The API supports all 28 Relaton flavors — 26 standards organizations plus DOI and ISBN identifier systems:
+
+ISO, IEC, IETF, ITU (T/D/R), NIST, BIPM, 3GPP, IEEE, W3C, CalConnect, OGC, IHO, OASIS, CIE, OMG, UN, GB, DOI, ISBN, ISSN, OGC, XSF, IEV, and more.
+
+For the full list with data sources, see the [Flavors page](/flavors/).
+
+## Rate Limits
+
+The API is provided as a public service for standards development. Please use responsibly — cache results locally when possible, and avoid bulk queries in tight loops.
+
+## Try It
+
+Enter a publication identifier below to see the response:
 
 <ApiDemo />

--- a/get-started.md
+++ b/get-started.md
@@ -1,0 +1,149 @@
+---
+title: Getting Started
+description: Install Relaton and fetch your first bibliographic record in under two minutes.
+---
+
+# Getting Started
+
+Relaton is a Ruby gem ecosystem for fetching, storing, and rendering bibliographic data about standards documents. This guide walks you through installation and your first lookup.
+
+## Prerequisites
+
+- **Ruby 3.0+** — check with `ruby -v`
+- **Bundler** (recommended) — `gem install bundler`
+
+## Install
+
+Install the core gem:
+
+```bash
+gem install relaton
+```
+
+Or add to your Gemfile:
+
+```ruby
+gem 'relaton'
+```
+
+## Your First Lookup
+
+Fetch a bibliographic record by its publication identifier:
+
+```ruby
+require 'relaton'
+
+bib = Relaton::Bibliography.get "ISO 690:2010"
+puts bib.to_xml
+```
+
+Relaton recognizes the `ISO 690:2010` identifier, routes the query to the ISO flavor gem, and returns a structured `BibliographicItem` with full metadata — title, dates, contributors, identifiers, relations, and more.
+
+## Fetch from Other Organizations
+
+Relaton supports 26 standards organizations and 2 identifier systems. Use the same API:
+
+```ruby
+# IETF RFC
+rfc = Relaton::Bibliography.get "RFC 8446"
+
+# ITU Recommendation
+itu = Relaton::Bibliography.get "ITU-T G.989.2"
+
+# NIST Special Publication
+nist = Relaton::Bibliography.get "NIST SP 800-188"
+
+# DOI lookup
+doi = Relaton::Bibliography.get "doi:10.1145/3448147"
+
+# ISBN lookup
+isbn = Relaton::Bibliography.get "ISBN 978-0-12-064481-0"
+```
+
+Each lookup returns a `BibliographicItem` with the same data model, regardless of source organization.
+
+## Serialize to Different Formats
+
+```ruby
+bib = Relaton::Bibliography.get "ISO 690:2010"
+
+# YAML (default)
+puts bib.to_hash.to_yaml
+
+# Relaton XML
+puts bib.to_xml
+
+# BibTeX
+puts bib.to_bibtex
+
+# AsciiBib
+puts bib.to_asciibib
+```
+
+See [Serializations](/model/serializations) for format details.
+
+## Use the CLI
+
+The `relaton-cli` gem provides command-line access:
+
+```bash
+gem install relaton-cli
+
+# Fetch and output in different formats
+relaton fetch "ISO 690:2010" --format yaml
+relaton fetch "ISO 690:2010" --format xml
+relaton fetch "ISO 690:2010" --format bibtex
+
+# Fetch and save to file
+relaton fetch "ISO 690:2010" -o iso690.yaml
+```
+
+## Render Citations
+
+The `relaton-render` gem formats bibliographic items for display:
+
+```ruby
+require 'relaton-render'
+
+bib = Relaton::Bibliography.get "ISO 690:2010"
+renderer = Relaton::Render::Iso::General.new
+puts renderer.render(bib)
+```
+
+Each flavor provides its own rendering template that follows the organization's citation style.
+
+## Data Model
+
+Every `BibliographicItem` follows the same structure, derived from [ISO 690](/model/iso-690/):
+
+- **Titles** — in multiple scripts and languages
+- **Contributors** — persons and organizations with typed roles
+- **Dates** — published, accessed, created, and more
+- **Identifiers** — document IDs, DOIs, ISBNs, URIs
+- **Relations** — replaces, amends, updates, derives, and 60+ more
+- **Extensions** — flavor-specific fields per SDO
+
+See the [full model documentation](/model/) for details on every entity.
+
+## Flavor Gems
+
+For direct access to a specific SDO's dataset, install the flavor gem:
+
+```bash
+gem install relaton-iso     # ISO
+gem install relaton-iec     # IEC
+gem install relaton-ietf    # IETF
+gem install relaton-itu     # ITU
+gem install relaton-nist    # NIST
+gem install relaton-bipm    # BIPM
+gem install relaton-3gpp    # 3GPP
+```
+
+See [all 33 gems](/software/) in the software catalog.
+
+## What's Next
+
+- [Model overview](/model/) — understand the BibliographicItem structure
+- [ISO 690 guidelines](/model/iso-690/) — the bibliographic standard behind Relaton
+- [Flavor extensions](/model/flavor-models) — per-organization model fields
+- [Serializations](/model/serializations) — YAML, XML, BibTeX, AsciiBib, JSON-LD

--- a/model/extensions.md
+++ b/model/extensions.md
@@ -290,5 +290,3 @@ The Relaton model is formally defined in:
 - **[relaton-model-3gpp](https://github.com/relaton/relaton-model-3gpp)** — 3GPP-specific model extensions
 - **[relaton-model-ieee](https://github.com/relaton/relaton-model-ieee)** — IEEE-specific model extensions
 - **[relaton-model-w3c](https://github.com/relaton/relaton-model-w3c)** — W3C-specific model extensions
-
-[View UML diagrams &rarr;](/model/diagrams) | [Flavor model extensions &rarr;](/model/flavor-models)

--- a/model/flavor-models.md
+++ b/model/flavor-models.md
@@ -279,5 +279,3 @@ Three flavors have dedicated formal model repositories with UML diagrams and sch
 | W3C | [relaton-model-w3c](https://github.com/relaton/relaton-model-w3c) | 3 model files, UML diagram |
 
 All use the same extension pattern: a flavor-specific class (e.g., `IeeeBibliographicItem`) inherits from the core `BibliographicItem` and adds domain-specific attributes.
-
-[View UML diagrams &rarr;](/model/diagrams) | [Extensions beyond ISO 690 &rarr;](/model/extensions)

--- a/model/iso-690/citation-systems.md
+++ b/model/iso-690/citation-systems.md
@@ -172,5 +172,3 @@ Services like the Internet Archive harvest and preserve web resources. Key guida
 **Relaton's approach:** The model supports all four strategies through typed URIs (`uri.citation`, `uri.xml`) and date tracking (`date.accessed`). The auto-fetch mechanism resolves PIDs to retrieve structured metadata.
 
 ---
-
-[Back to ISO 690 overview](/model/iso-690/) | [Extensions beyond ISO 690 &rarr;](/model/extensions)

--- a/model/iso-690/index.md
+++ b/model/iso-690/index.md
@@ -80,8 +80,7 @@ These are the problems Relaton solves.
 ## Explore the Companion Guide
 
 - [Principles](/model/iso-690/principles) — The four principles and seven guidelines for creating accurate references
-- [Data Elements](/model/iso-690/data-elements) — All 14 data element categories with rules and examples
 - [Resource Types](/model/iso-690/resource-types) — Citation guidelines for 16 kinds of information resources
 - [Citation Systems](/model/iso-690/citation-systems) — Five methods for linking in-text citations to references
 
-[Extensions beyond ISO 690 &rarr;](/model/extensions) | [Flavor model extensions &rarr;](/model/flavor-models)
+The 14 ISO 690 data elements are documented as individual model entities — see the sidebar under "Core Entities" and "Descriptive Elements".

--- a/model/iso-690/principles.md
+++ b/model/iso-690/principles.md
@@ -97,5 +97,3 @@ Human-readable sources should be preferred over machine-readable ones when possi
 If metadata appears in different forms within the same resource, use the most prominent form unless it is obviously wrong (e.g., an incorrect disc label). If metadata differs across multiple cited resources, use the form most commonly used in the language of the publication.
 
 ---
-
-[Back to ISO 690 overview](/model/iso-690/) | [Data Elements &rarr;](/model/iso-690/data-elements)

--- a/model/iso-690/resource-types.md
+++ b/model/iso-690/resource-types.md
@@ -259,5 +259,3 @@ Relaton's `BibitemType` enumeration provides complete coverage, combining ISO 69
 `article`, `book`, `booklet`, `manual`, `proceedings`, `presentation`, `thesis`, `techReport`, `standard`, `unpublished`, `map`, `electronicResource`, `audiovisual`, `film`, `video`, `broadcast`, `graphicWork`, `music`, `patent`, `inBook`, `inCollection`, `inProceedings`, `journal`, `webResource`, `website`, `dataset`, `archival`, `software`, `socialMedia`, `alert`, `message`, `conversation`, `misc`
 
 The resource type drives rendering decisions — what fields to display, in what order, and with what formatting.
-
-[Back to ISO 690 overview](/model/iso-690/) | [Citation Systems &rarr;](/model/iso-690/citation-systems)


### PR DESCRIPTION
## Summary

Fixes content gaps, design inconsistencies, UX issues, and dead links across the site.

### Content
- Add Getting Started page (`/get-started/`) with install, first lookup, CLI, and rendering sections
- Wire hero CTA "Get Started" to the new page instead of `/software/`
- Add full API documentation above the demo form (`/api/`)
- Fix numeric inconsistencies: 29 flavor gems, 33 total gems, 26 orgs + 2 identifier systems
- Update ISO 690 index to reference sidebar-split entity pages instead of deleted data-elements monolith

### Design
- Replace home page FlavorGrid (29 cards inline) with compact marquee + "View all" link
- Extract shared `.badge` and `.rendered-content` styles from 4 components into `custom.css`
- Fix theme-color meta tag typo `#1F6CF0` → `#1F6CF1`

### UX
- Add cross-links from flavor pages to corresponding software pages
- Add copy-to-clipboard "Copied!" feedback on FlavorPage and SoftwarePage
- Add ARIA labels on search inputs (FlavorGrid, SoftwareGrid)
- Add "not found" state to SoftwarePage

### Cleanup
- Remove 6 manually maintained footer nav links across model docs
- Remove dead link to deleted `/model/iso-690/data-elements`
- Set `ignoreDeadLinks: false` — build now catches broken links
- Fix missing `ref` import in FlavorPage