### PR TITLE
refactor: DRY design system, data-driven content, shared components

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
     ['meta', { name: 'theme-color', content: '#1F6CF1' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: 'Relaton' }],
+    ['meta', { name: 'twitter:card', content: 'summary' }],
+    ['meta', { name: 'twitter:site', content: '@riboseinc' }],
   ],
 
   themeConfig: {

--- a/.vitepress/data/software.ts
+++ b/.vitepress/data/software.ts
@@ -8,6 +8,7 @@ export const gems: SoftwareGem[] = [
     repoUrl: 'https://github.com/metanorma/relaton',
     description: 'Core gem for importing and caching bibliographic references to technical standards.',
     category: 'core',
+    sampleDocId: 'ISO 690:2010',
   },
   {
     id: 'relaton-bib',
@@ -16,6 +17,15 @@ export const gems: SoftwareGem[] = [
     repoUrl: 'https://github.com/relaton/relaton-bib',
     description: 'Implements the BibliographicItem model — the foundation of the Relaton data model.',
     category: 'core',
+    quickStartOverride: `require 'relaton-bib'
+
+item = RelatonBib::BibliographicItem.new(
+  title: [{ content: "Example Standard", language: "en", script: "Latn" }],
+  docid: [{ id: "EX 1:2024", type: "EX" }],
+  date: [{ type: "published", value: "2024" }],
+  type: "standard"
+)
+puts item.to_xml`,
   },
   {
     id: 'relaton-cli',
@@ -24,6 +34,13 @@ export const gems: SoftwareGem[] = [
     repoUrl: 'https://github.com/relaton/relaton-cli',
     description: 'Command-line tools for building, fetching, and converting Relaton bibliographic data.',
     category: 'tool',
+    quickStartOverride: `# Fetch in different formats
+relaton fetch "ISO 690:2010" --format yaml
+relaton fetch "ISO 690:2010" --format xml
+relaton fetch "RFC 8446" --format bibtex
+
+# Fetch and save to file
+relaton fetch "ISO 690:2010" -o iso690.yaml`,
   },
   {
     id: 'relaton-render',
@@ -32,6 +49,11 @@ export const gems: SoftwareGem[] = [
     repoUrl: 'https://github.com/metanorma/relaton-render',
     description: 'Formats bibliographic references in ISO 690, APA, MLA, and custom styles.',
     category: 'tool',
+    quickStartOverride: `require 'relaton-render'
+
+bib = Relaton::Bibliography.get "ISO 690:2010"
+renderer = Relaton::Render::Iso::General.new
+puts renderer.render(bib)`,
   },
   {
     id: 'relaton-iso',
@@ -41,6 +63,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves ISO Standards from iso.org for bibliographic use.',
     category: 'flavor',
     flavorId: 'iso',
+    sampleDocId: 'ISO 690:2010',
   },
   {
     id: 'relaton-iec',
@@ -50,6 +73,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves IEC/CIE Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'iec',
+    sampleDocId: 'IEC 60050-111:2019',
   },
   {
     id: 'relaton-ietf',
@@ -59,6 +83,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves IETF RFC standards.',
     category: 'flavor',
     flavorId: 'ietf',
+    sampleDocId: 'RFC 8446',
   },
   {
     id: 'relaton-ieee',
@@ -68,6 +93,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves IEEE Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'ieee',
+    sampleDocId: 'IEEE 802.1Q',
   },
   {
     id: 'relaton-itu',
@@ -77,6 +103,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves ITU standards.',
     category: 'flavor',
     flavorId: 'itu',
+    sampleDocId: 'ITU-T G.989.2',
   },
   {
     id: 'relaton-nist',
@@ -86,6 +113,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves NIST standards.',
     category: 'flavor',
     flavorId: 'nist',
+    sampleDocId: 'NIST SP 800-188',
   },
   {
     id: 'relaton-bipm',
@@ -95,6 +123,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves BIPM Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'bipm',
+    sampleDocId: 'BIPM SI Brochure',
   },
   {
     id: 'relaton-3gpp',
@@ -104,6 +133,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves 3GPP Standards for bibliographic use.',
     category: 'flavor',
     flavorId: '3gpp',
+    sampleDocId: '3GPP TS 23.501',
   },
   {
     id: 'relaton-ogc',
@@ -113,6 +143,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves OGC Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'ogc',
+    sampleDocId: 'OGC 06-103r4',
   },
   {
     id: 'relaton-iev',
@@ -122,6 +153,7 @@ export const gems: SoftwareGem[] = [
     description: 'Refactors IEV references.',
     category: 'flavor',
     flavorId: 'iev',
+    sampleDocId: 'IEC 60050-102',
   },
   {
     id: 'relaton-oasis',
@@ -131,6 +163,7 @@ export const gems: SoftwareGem[] = [
     description: 'Searches and fetches OASIS OPEN standards.',
     category: 'flavor',
     flavorId: 'oasis',
+    sampleDocId: 'OASIS CAP v1.2',
   },
   {
     id: 'relaton-cie',
@@ -140,6 +173,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves CIE Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'cie',
+    sampleDocId: 'CIE S 017/E:2011',
   },
   {
     id: 'relaton-w3c',
@@ -149,6 +183,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves W3C Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'w3c',
+    sampleDocId: 'W3C REC-json-ld11-20200716',
   },
   {
     id: 'relaton-ecma',
@@ -158,6 +193,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves ECMA Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'ecma',
+    sampleDocId: 'ECMA-262',
   },
   {
     id: 'relaton-iho',
@@ -167,6 +203,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves IHO Standards from iho.int.',
     category: 'flavor',
     flavorId: 'iho',
+    sampleDocId: 'IHO S-57',
   },
   {
     id: 'relaton-omg',
@@ -176,6 +213,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves OMG Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'omg',
+    sampleDocId: 'OMG UML 2.5.1',
   },
   {
     id: 'relaton-un',
@@ -185,6 +223,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves UN Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'un',
+    sampleDocId: 'UN ECE/TRADE/423',
   },
   {
     id: 'relaton-cen',
@@ -194,6 +233,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves CEN Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'cen',
+    sampleDocId: 'EN 206:2013',
   },
   {
     id: 'relaton-bsi',
@@ -203,6 +243,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves BSI Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'bsi',
+    sampleDocId: 'BS 5930:2015',
   },
   {
     id: 'relaton-jis',
@@ -212,6 +253,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves JIS Standards from webdesk.jsa.or.jp.',
     category: 'flavor',
     flavorId: 'jis',
+    sampleDocId: 'JIS B 0175',
   },
   {
     id: 'relaton-gb',
@@ -221,6 +263,7 @@ export const gems: SoftwareGem[] = [
     description: 'Searches and fetches Chinese GB standards.',
     category: 'flavor',
     flavorId: 'gb',
+    sampleDocId: 'GB/T 1.1',
   },
   {
     id: 'relaton-calconnect',
@@ -230,6 +273,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves CalConnect Standards from calconnect.org.',
     category: 'flavor',
     flavorId: 'calconnect',
+    sampleDocId: 'CC/BP 01001:2020',
   },
   {
     id: 'relaton-ccsds',
@@ -239,6 +283,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves CCSDS Standards from ccsds.org.',
     category: 'flavor',
     flavorId: 'ccsds',
+    sampleDocId: 'CCSDS 122.0-B-1',
   },
   {
     id: 'relaton-iana',
@@ -248,6 +293,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves IANA Standards for bibliographic use.',
     category: 'flavor',
     flavorId: 'iana',
+    sampleDocId: 'charset/UTF-8',
   },
   {
     id: 'relaton-xsf',
@@ -257,6 +303,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves XSF Standards from xmpp.org/extensions/.',
     category: 'flavor',
     flavorId: 'xsf',
+    sampleDocId: 'XEP-0045',
   },
   {
     id: 'relaton-doi',
@@ -266,6 +313,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves DOI metadata from Crossref API.',
     category: 'flavor',
     flavorId: 'doi',
+    sampleDocId: 'doi:10.1145/3448147',
   },
   {
     id: 'relaton-isbn',
@@ -275,6 +323,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves ISBN publications from OpenLibrary.',
     category: 'flavor',
     flavorId: 'isbn',
+    sampleDocId: 'ISBN 978-0-12-064481-0',
   },
   {
     id: 'relaton-plateau',
@@ -284,6 +333,7 @@ export const gems: SoftwareGem[] = [
     description: 'Retrieves MLIT PLATEAU publications for bibliographic use.',
     category: 'flavor',
     flavorId: 'plateau',
+    sampleDocId: 'MLIT PLATEAU 2.0',
   },
   {
     id: 'relaton-iso-bib',
@@ -293,5 +343,6 @@ export const gems: SoftwareGem[] = [
     description: 'Implements the IsoBibliographicItem model.',
     category: 'flavor',
     flavorId: 'iso',
+    sampleDocId: 'ISO 690:2010',
   },
 ]

--- a/.vitepress/data/types.ts
+++ b/.vitepress/data/types.ts
@@ -56,6 +56,8 @@ export interface SoftwareGem {
   description: string
   category: 'core' | 'tool' | 'flavor'
   flavorId?: string
+  sampleDocId?: string
+  quickStartOverride?: string
 }
 
 export interface BlogPost {

--- a/.vitepress/theme/components/BlogIndex.vue
+++ b/.vitepress/theme/components/BlogIndex.vue
@@ -62,7 +62,7 @@ function formatDate(date: string): string {
   transition: border-color 0.15s, background 0.15s;
 }
 .blog-item:hover {
-  border-color: rgba(31,108,241,0.3);
+  border-color: var(--c-brand-border);
 }
 
 .blog-item-meta {
@@ -90,7 +90,7 @@ function formatDate(date: string): string {
   transition: color 0.15s;
 }
 .blog-item:hover .blog-item-title {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 
 .blog-item-desc {
@@ -110,7 +110,7 @@ function formatDate(date: string): string {
   gap: 4px;
   font-size: 13px;
   font-weight: 500;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 .blog-item-link svg {
   transition: transform 0.15s;

--- a/.vitepress/theme/components/FlavorExtensions.vue
+++ b/.vitepress/theme/components/FlavorExtensions.vue
@@ -140,17 +140,17 @@ defineProps<{
   flex-wrap: wrap;
 }
 .ext-inheritance a {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   text-decoration: none;
   font-weight: 500;
 }
 .ext-inherits-label {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   font-weight: 500;
 }
 .ext-badge {
   background: var(--vp-c-brand-soft);
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   font-size: 11px;
   font-weight: 600;
   padding: 2px 8px;
@@ -261,7 +261,7 @@ defineProps<{
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   font-size: 13px;
   font-weight: 500;
   text-decoration: none;

--- a/.vitepress/theme/components/FlavorGrid.vue
+++ b/.vitepress/theme/components/FlavorGrid.vue
@@ -1,28 +1,12 @@
 <template>
   <div class="flavor-grid">
-    <div class="grid-controls">
-      <div class="search-wrap">
-        <svg class="search-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-        <input
-          v-model="search"
-          type="text"
-          placeholder="Search organizations…"
-          aria-label="Search organizations"
-          class="search-input"
-        />
-      </div>
-      <div class="filter-tabs">
-        <button
-          v-for="cat in categories"
-          :key="cat.value"
-          :class="['tab', { active: activeCategory === cat.value }]"
-          @click="activeCategory = cat.value"
-        >
-          {{ cat.label }}
-          <span v-if="cat.count" class="tab-count">{{ cat.count }}</span>
-        </button>
-      </div>
-    </div>
+    <GridControls
+      v-model:search="search"
+      v-model:active-category="activeCategory"
+      placeholder="Search organizations…"
+      aria-label="Search organizations"
+      :categories="categories"
+    />
 
     <div class="grid">
       <a
@@ -64,6 +48,7 @@
 import { ref, computed } from 'vue'
 import { flavors } from '../../data/flavors'
 import { categoryLabel } from '../../data/categories'
+import GridControls from './GridControls.vue'
 
 const search = ref('')
 const activeCategory = ref('all')
@@ -99,82 +84,6 @@ const filteredFlavors = computed(() => {
   margin-top: 8px;
 }
 
-.grid-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  align-items: center;
-  margin-bottom: 24px;
-}
-
-.search-wrap {
-  position: relative;
-  flex-shrink: 0;
-}
-.search-icon {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--vp-c-text-3);
-  pointer-events: none;
-}
-.search-input {
-  width: 260px;
-  padding: 9px 14px 9px 36px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
-  font-size: 13px;
-  font-family: inherit;
-  background: var(--vp-c-bg);
-  color: var(--vp-c-text-1);
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-.search-input:focus {
-  outline: none;
-  border-color: #1F6CF1;
-  box-shadow: 0 0 0 3px rgba(31,108,241,0.1);
-}
-
-.filter-tabs {
-  display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
-}
-
-.tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 14px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 20px;
-  font-size: 12px;
-  font-weight: 500;
-  background: var(--vp-c-bg);
-  color: var(--vp-c-text-2);
-  cursor: pointer;
-  transition: all 0.15s;
-  font-family: inherit;
-}
-.tab:hover {
-  border-color: rgba(31,108,241,0.4);
-  color: #1F6CF1;
-}
-.tab.active {
-  background: #1F6CF1;
-  border-color: #1F6CF1;
-  color: #fff;
-}
-.tab-count {
-  font-size: 10px;
-  font-weight: 600;
-  opacity: 0.6;
-}
-.tab.active .tab-count {
-  opacity: 0.8;
-}
-
 .grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -194,7 +103,7 @@ const filteredFlavors = computed(() => {
   transition: border-color 0.15s, background 0.15s;
 }
 .flavor-card:hover {
-  border-color: rgba(31,108,241,0.3);
+  border-color: var(--c-brand-border);
 }
 
 .flavor-card-top {
@@ -222,7 +131,7 @@ const filteredFlavors = computed(() => {
   border: 1px solid var(--vp-c-divider);
   font-size: 16px;
   font-weight: 700;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   font-family: 'Outfit', sans-serif;
 }
 
@@ -254,7 +163,7 @@ const filteredFlavors = computed(() => {
 .flavor-card:hover .flavor-arrow {
   opacity: 1;
   transform: translateX(2px);
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 
 .empty-state {
@@ -268,8 +177,6 @@ const filteredFlavors = computed(() => {
 }
 @media (max-width: 768px) {
   .grid { grid-template-columns: repeat(2, 1fr); }
-  .grid-controls { flex-direction: column; align-items: stretch; }
-  .search-input { width: 100%; }
 }
 @media (max-width: 480px) {
   .grid { grid-template-columns: 1fr; }

--- a/.vitepress/theme/components/FlavorPage.vue
+++ b/.vitepress/theme/components/FlavorPage.vue
@@ -154,7 +154,7 @@ async function copyInstall() {
   border: 1px solid var(--vp-c-divider);
   font-size: 22px;
   font-weight: 700;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   font-family: 'Outfit', sans-serif;
 }
 
@@ -199,7 +199,7 @@ async function copyInstall() {
   align-items: center;
   gap: 5px;
   font-size: 13px;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   text-decoration: none;
   font-weight: 500;
   padding: 4px 10px;
@@ -209,7 +209,7 @@ async function copyInstall() {
 }
 .source-link:hover {
   background: rgba(31,108,241,0.06);
-  border-color: rgba(31,108,241,0.4);
+  border-color: var(--c-brand-border-strong);
 }
 .source-link svg {
   flex-shrink: 0;
@@ -239,12 +239,12 @@ async function copyInstall() {
   transition: border-color 0.15s;
 }
 .software-card:hover {
-  border-color: rgba(31,108,241,0.3);
+  border-color: var(--c-brand-border);
 }
 
 .software-card-accent {
   height: 3px;
-  background: linear-gradient(90deg, #1F6CF1, #21C197);
+  background: linear-gradient(90deg, var(--vp-c-brand-1), #21C197);
 }
 
 .software-card-body {
@@ -259,7 +259,7 @@ async function copyInstall() {
   height: 36px;
   border-radius: 8px;
   background: rgba(31,108,241,0.08);
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   margin-bottom: 12px;
 }
 
@@ -310,7 +310,7 @@ async function copyInstall() {
   transition: color 0.15s;
 }
 .copy-btn:hover {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 
 .software-links {
@@ -324,7 +324,7 @@ async function copyInstall() {
   gap: 6px;
   font-size: 13px;
   font-weight: 500;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   text-decoration: none;
   transition: opacity 0.15s;
 }
@@ -346,7 +346,7 @@ async function copyInstall() {
 }
 .copy-feedback {
   font-size: 11px;
-  color: #059669;
+  color: var(--c-success);
   font-weight: 600;
 }
 </style>

--- a/.vitepress/theme/components/GridControls.vue
+++ b/.vitepress/theme/components/GridControls.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="grid-controls">
+    <div class="search-wrap">
+      <svg class="search-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+      <input
+        v-model="search"
+        type="text"
+        :placeholder="placeholder"
+        :aria-label="ariaLabel"
+        class="search-input"
+      />
+    </div>
+    <div class="filter-tabs">
+      <button
+        v-for="cat in categories"
+        :key="cat.value"
+        :class="['tab', { active: activeCategory === cat.value }]"
+        @click="activeCategory = cat.value"
+      >
+        {{ cat.label }}
+        <span v-if="cat.count" class="tab-count">{{ cat.count }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface FilterCategory {
+  label: string
+  value: string
+  count?: number
+}
+
+defineProps<{
+  placeholder: string
+  ariaLabel: string
+  categories: FilterCategory[]
+}>()
+
+const search = defineModel<string>('search', { default: '' })
+const activeCategory = defineModel<string>('activeCategory', { default: 'all' })
+</script>
+
+<style scoped>
+.grid-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.search-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+.search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--vp-c-text-3);
+  pointer-events: none;
+}
+.search-input {
+  width: 260px;
+  padding: 9px 14px 9px 36px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.search-input:focus {
+  outline: none;
+  border-color: var(--vp-c-brand-1);
+  box-shadow: 0 0 0 3px var(--vp-c-brand-soft);
+}
+
+.filter-tabs {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 14px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+.tab:hover {
+  border-color: var(--c-brand-border-strong);
+  color: var(--vp-c-brand-1);
+}
+.tab.active {
+  background: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+  color: #fff;
+}
+.tab-count {
+  font-size: 10px;
+  font-weight: 600;
+  opacity: 0.6;
+}
+.tab.active .tab-count {
+  opacity: 0.8;
+}
+
+@media (max-width: 768px) {
+  .grid-controls { flex-direction: column; align-items: stretch; }
+  .search-input { width: 100%; }
+}
+</style>

--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -57,7 +57,10 @@
                   >{{ tab.label }}</button>
                 </div>
                 <button class="code-copy" @click="copyCode" title="Copy">
-                  <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  <template v-if="!codeCopied">
+                    <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                  </template>
+                  <span v-else class="code-copy-feedback">Copied!</span>
                 </button>
               </div>
               <div class="code-body">
@@ -240,8 +243,14 @@ onMounted(() => {
 const activeTab = ref('yaml')
 const currentCode = computed(() => d.codeExamples[activeTab.value] || '')
 
+const codeCopied = ref(false)
+let codeCopyTimer: ReturnType<typeof setTimeout>
+
 async function copyCode() {
   await navigator.clipboard.writeText(currentCode.value)
+  codeCopied.value = true
+  clearTimeout(codeCopyTimer)
+  codeCopyTimer = setTimeout(() => { codeCopied.value = false }, 1500)
 }
 
 function formatDate(date: string): string {
@@ -312,7 +321,7 @@ function formatDate(date: string): string {
   color: #fff;
 }
 .hero-title-accent {
-  background: linear-gradient(135deg, #1F6CF1 0%, #21C197 100%);
+  background: linear-gradient(135deg, var(--vp-c-brand-1) 0%, #21C197 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -444,6 +453,11 @@ function formatDate(date: string): string {
 .code-copy:hover {
   color: rgba(255,255,255,0.7);
 }
+.code-copy-feedback {
+  font-size: 11px;
+  color: var(--c-success);
+  font-weight: 600;
+}
 
 .code-body {
   padding: 16px 20px;
@@ -514,7 +528,7 @@ function formatDate(date: string): string {
   margin-top: 40px;
 }
 .link-arrow {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   font-weight: 500;
   font-size: 14px;
   text-decoration: none;
@@ -563,7 +577,7 @@ function formatDate(date: string): string {
   width: 4px;
   flex-shrink: 0;
 }
-.layer-standard { background: linear-gradient(180deg, #1F6CF1, #4D88F3); }
+.layer-standard { background: linear-gradient(180deg, var(--vp-c-brand-1), #4D88F3); }
 .layer-model { background: linear-gradient(180deg, #008A64, #21C197); }
 .layer-serial { background: linear-gradient(180deg, #21C197, #34D399); }
 .layer-fetch { background: linear-gradient(180deg, #4D88F3, #7EAAF5); }
@@ -615,7 +629,7 @@ function formatDate(date: string): string {
 .eco-accent {
   height: 3px;
 }
-.accent-blue { background: linear-gradient(90deg, #1F6CF1, #4D88F3); }
+.accent-blue { background: linear-gradient(90deg, var(--vp-c-brand-1), #4D88F3); }
 .accent-aqua { background: linear-gradient(90deg, #21C197, #34D399); }
 .accent-green { background: linear-gradient(90deg, #008A64, #21C197); }
 
@@ -669,7 +683,7 @@ function formatDate(date: string): string {
   transition: color 0.15s;
 }
 .blog-card:hover .blog-card-title {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 .blog-card-desc {
   font-size: 13px;
@@ -684,7 +698,7 @@ function formatDate(date: string): string {
 .blog-card-link {
   font-size: 13px;
   font-weight: 500;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 
 /* ── CTA Section ──────────────────────────────────────── */
@@ -812,5 +826,9 @@ function formatDate(date: string): string {
   color: var(--vp-c-text-2);
   text-align: center;
   line-height: 1.2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .org-marquee-track { animation: none; }
 }
 </style>

--- a/.vitepress/theme/components/ModelDiagram.vue
+++ b/.vitepress/theme/components/ModelDiagram.vue
@@ -32,7 +32,7 @@ defineProps<{ src?: string; alt?: string }>()
   bottom: 10%;
   width: 3px;
   border-radius: 0 3px 3px 0;
-  background: linear-gradient(180deg, #1F6CF1, #21C197);
+  background: linear-gradient(180deg, var(--vp-c-brand-1), var(--c-accent));
   opacity: 0.4;
 }
 

--- a/.vitepress/theme/components/SoftwareGrid.vue
+++ b/.vitepress/theme/components/SoftwareGrid.vue
@@ -1,28 +1,12 @@
 <template>
   <div class="software-grid">
-    <div class="grid-controls">
-      <div class="search-wrap">
-        <svg class="search-icon" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-        <input
-          v-model="search"
-          type="text"
-          placeholder="Search gems…"
-          aria-label="Search gems"
-          class="search-input"
-        />
-      </div>
-      <div class="filter-tabs">
-        <button
-          v-for="cat in categories"
-          :key="cat.value"
-          :class="['tab', { active: activeCategory === cat.value }]"
-          @click="activeCategory = cat.value"
-        >
-          {{ cat.label }}
-          <span v-if="cat.count" class="tab-count">{{ cat.count }}</span>
-        </button>
-      </div>
-    </div>
+    <GridControls
+      v-model:search="search"
+      v-model:active-category="activeCategory"
+      placeholder="Search gems…"
+      aria-label="Search gems"
+      :categories="categories"
+    />
 
     <div class="grid">
       <a
@@ -56,6 +40,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { gems } from '../../data/software'
+import GridControls from './GridControls.vue'
 
 const search = ref('')
 const activeCategory = ref('all')
@@ -85,57 +70,6 @@ const filteredGems = computed(() => {
 <style scoped>
 .software-grid { margin-top: 8px; }
 
-.grid-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  align-items: center;
-  margin-bottom: 24px;
-}
-.search-wrap { position: relative; flex-shrink: 0; }
-.search-icon {
-  position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--vp-c-text-3);
-  pointer-events: none;
-}
-.search-input {
-  width: 260px;
-  padding: 9px 14px 9px 36px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 10px;
-  font-size: 13px;
-  font-family: inherit;
-  background: var(--vp-c-bg);
-  color: var(--vp-c-text-1);
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-.search-input:focus {
-  outline: none;
-  border-color: #1F6CF1;
-  box-shadow: 0 0 0 3px rgba(31,108,241,0.1);
-}
-
-.filter-tabs { display: flex; gap: 4px; flex-wrap: wrap; }
-.tab {
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 6px 14px;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 20px;
-  font-size: 12px; font-weight: 500;
-  background: var(--vp-c-bg);
-  color: var(--vp-c-text-2);
-  cursor: pointer;
-  transition: all 0.15s;
-  font-family: inherit;
-}
-.tab:hover { border-color: rgba(31,108,241,0.4); color: #1F6CF1; }
-.tab.active { background: #1F6CF1; border-color: #1F6CF1; color: #fff; }
-.tab-count { font-size: 10px; font-weight: 600; opacity: 0.6; }
-.tab.active .tab-count { opacity: 0.8; }
-
 .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
 
 .gem-card {
@@ -149,7 +83,7 @@ const filteredGems = computed(() => {
   background: var(--vp-c-bg);
   transition: border-color 0.15s, background 0.15s;
 }
-.gem-card:hover { border-color: rgba(31,108,241,0.3); }
+.gem-card:hover { border-color: var(--c-brand-border); }
 
 .gem-header {
   display: flex; justify-content: space-between;
@@ -182,15 +116,13 @@ const filteredGems = computed(() => {
   transition: opacity 0.15s, transform 0.15s;
 }
 .gem-card:hover .gem-arrow {
-  opacity: 1; transform: translateX(2px); color: #1F6CF1;
+  opacity: 1; transform: translateX(2px); color: var(--vp-c-brand-1);
 }
 
 .empty-state { text-align: center; color: var(--vp-c-text-3); padding: 48px 0; }
 
 @media (max-width: 768px) {
   .grid { grid-template-columns: repeat(2, 1fr); }
-  .grid-controls { flex-direction: column; align-items: stretch; }
-  .search-input { width: 100%; }
 }
 @media (max-width: 480px) {
   .grid { grid-template-columns: 1fr; }

--- a/.vitepress/theme/components/SoftwarePage.vue
+++ b/.vitepress/theme/components/SoftwarePage.vue
@@ -109,12 +109,13 @@ const relatedFlavor = computed(() => {
 })
 
 const quickStartCode = computed(() => {
-  const name = props.gem?.name || 'relaton'
-  const module = name.split('-').map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('')
-  return `require '${name}'
+  if (!props.gem) return ''
+  if (props.gem.quickStartOverride) return props.gem.quickStartOverride
+  const docId = props.gem.sampleDocId || 'ISO 690:2010'
+  return `require 'relaton'
 
 # Fetch a bibliographic item
-bib = ${module}::Bibliography.get("ISO 690:2010")
+bib = Relaton::Bibliography.get "${docId}"
 puts bib.to_xml`
 })
 
@@ -202,7 +203,7 @@ async function copy(text: string) {
   font-weight: 500;
   text-decoration: none;
   transition: all 0.15s;
-  background: #1F6CF1;
+  background: var(--vp-c-brand-1);
   color: #fff;
 }
 .sp-action-btn:hover { background: #1560D8; }
@@ -212,8 +213,8 @@ async function copy(text: string) {
   color: var(--vp-c-text-2);
 }
 .sp-action-btn--outline:hover {
-  border-color: rgba(31,108,241,0.4);
-  color: #1F6CF1;
+  border-color: var(--c-brand-border-strong);
+  color: var(--vp-c-brand-1);
   background: rgba(31,108,241,0.04);
 }
 
@@ -282,7 +283,7 @@ async function copy(text: string) {
   margin-left: auto;
   flex-shrink: 0;
 }
-.sp-copy:hover { color: #1F6CF1; }
+.sp-copy:hover { color: var(--vp-c-brand-1); }
 .sp-copy--corner {
   position: absolute;
   top: 12px;
@@ -309,10 +310,10 @@ async function copy(text: string) {
 }
 .sp-link-card svg {
   flex-shrink: 0;
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 .sp-link-card:hover {
-  border-color: rgba(31,108,241,0.3);
+  border-color: var(--c-brand-border);
 }
 
 .sp-link-card-label {
@@ -339,12 +340,12 @@ async function copy(text: string) {
   transition: border-color 0.15s;
 }
 .sp-related-card:hover {
-  border-color: rgba(31,108,241,0.3);
+  border-color: var(--c-brand-border);
 }
 
 .sp-related-accent {
   height: 3px;
-  background: linear-gradient(90deg, #21C197, #1F6CF1);
+  background: linear-gradient(90deg, #21C197, var(--vp-c-brand-1));
 }
 
 .sp-related-body {
@@ -364,7 +365,7 @@ async function copy(text: string) {
   height: 32px;
   border-radius: 8px;
   background: rgba(33,193,151,0.08);
-  color: #059669;
+  color: var(--c-success);
   flex-shrink: 0;
 }
 
@@ -375,7 +376,7 @@ async function copy(text: string) {
 }
 .sp-related-card:hover .sp-related-arrow {
   transform: translateX(3px);
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
 }
 
 @media (max-width: 640px) {
@@ -391,7 +392,7 @@ async function copy(text: string) {
 
 .sp-copy-feedback {
   font-size: 11px;
-  color: #059669;
+  color: var(--c-success);
   font-weight: 600;
 }
 .sp-not-found {
@@ -400,7 +401,7 @@ async function copy(text: string) {
   color: var(--vp-c-text-3);
 }
 .sp-back-link {
-  color: #1F6CF1;
+  color: var(--vp-c-brand-1);
   text-decoration: none;
   font-weight: 500;
 }

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -18,6 +18,12 @@
   --vp-c-brand-3: #1F6CF1;
   --vp-c-brand-soft: rgba(31, 108, 241, 0.10);
 
+  --c-brand-border: rgba(31, 108, 241, 0.3);
+  --c-brand-border-strong: rgba(31, 108, 241, 0.4);
+  --c-accent: #21C197;
+  --c-accent-dark: #008A64;
+  --c-success: #059669;
+
   /* Surfaces */
   --vp-c-bg: #FFFFFF;
   --vp-c-bg-soft: #F8FAFB;

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -10,6 +10,7 @@ import SoftwareGrid from './components/SoftwareGrid.vue'
 import BlogIndex from './components/BlogIndex.vue'
 import BlogByline from './components/BlogByline.vue'
 import ModelDiagram from './components/ModelDiagram.vue'
+import GridControls from './components/GridControls.vue'
 import ApiDemo from './components/ApiDemo.vue'
 import SiteFooter from './components/SiteFooter.vue'
 import { h } from 'vue'
@@ -26,6 +27,7 @@ export default {
     app.component('BlogByline', BlogByline)
     app.component('ModelDiagram', ModelDiagram)
     app.component('ApiDemo', ApiDemo)
+    app.component('GridControls', GridControls)
   },
   Layout() {
     return h(DefaultTheme.Layout, null, {

--- a/about.md
+++ b/about.md
@@ -35,14 +35,14 @@ Together, the name captures the essence of the project: that bibliographic data 
 
 The Relaton logo depicts a **network of four interconnected nodes**, each radiating connections to the others through branching paths. This is not arbitrary decoration — it is a direct visual representation of what Relaton models:
 
+- **The circles and squares** draw on an ancient East Asian principle: *heaven is round, the earth is square* (天圓地方). The circle represents the boundless, the abstract, the ideal form of knowledge — the Platonic category that a standard aspires to. The square represents the concrete, the structured, the grounded instance — a specific document, a particular edition, a tangible artifact. In Relaton, these two shapes coexist because every bibliographic record lives in both worlds: the universal concept of a work and the particular manifestation you hold in your hands. The circles and squares flow into one another because a work can be born from the relationship between other works, just as the ancients understood that heaven and earth give rise to all things through their interplay.
 - **The nodes** represent bibliographic entities — standards, papers, datasets, any citable work. Four are shown, but the network extends infinitely in every direction, just as the body of scholarly and technical literature grows without bound.
 - **The connecting paths** represent the 60+ typed relations that Relaton defines between documents: *replaces*, *amends*, *derives from*, *has part*, *obsoletes*, *updates*, and many more. The paths branch and overlap because real-world bibliographic relationships are not one-to-one — a single standard may simultaneously reference, replace, and subsume multiple other works.
-- **The central square** formed where paths intersect represents the Relaton model itself — the structured, machine-readable framework through which all these relationships are expressed and traversed.
 - **The symmetry** of the pattern reflects the model's design principle: every relation has a defined inverse, every connection is bidirectional, and the model treats all bibliographic entities with equal rigor regardless of their source organization.
 
 ### The Color
 
-The logo's blue (**#1F6CF0**) is a deliberate choice. Blue is the color of **trust, authority, and permanence** — the same qualities that define the international standards Relaton serves. It is the color of the ISO wordmark, of academic institutions, and of the hyperlinks that connect the web of knowledge. In the context of bibliographic data, blue signifies reliability: when a machine reads a Relaton record, it can trust that every relation, every identifier, every metadata element has been structured with the precision that standards demand.
+The logo's blue (**#1F6CF1**) is a deliberate choice. Blue is the color of **trust, authority, and permanence** — the same qualities that define the international standards Relaton serves. It is the color of the ISO wordmark, of academic institutions, and of the hyperlinks that connect the web of knowledge. In the context of bibliographic data, blue signifies reliability: when a machine reads a Relaton record, it can trust that every relation, every identifier, every metadata element has been structured with the precision that standards demand.
 
 ## What Relaton Does
 
@@ -111,10 +111,10 @@ Key adopters of Relaton:
 
 | Component | Purpose | Link |
 |---|---|---|
-| relaton-bib | Core BibliographicItem model | [GitHub](https://github.com/relaton/relaton-bib) |
-| relaton | Cache management and gateway | [GitHub](https://github.com/metanorma/relaton) |
-| relaton-cli | Command-line interface | [GitHub](https://github.com/relaton/relaton-cli) |
-| relaton-render | Reference formatting (ISO 690 styles) | [GitHub](https://github.com/metanorma/relaton-render) |
+| relaton-bib | Core BibliographicItem model | [Software](/software/relaton-bib) |
+| relaton | Cache management and gateway | [Software](/software/relaton) |
+| relaton-cli | Command-line interface | [Software](/software/relaton-cli) |
+| relaton-render | Reference formatting (ISO 690 styles) | [Software](/software/relaton-render) |
 | 29 flavor gems | SDO-specific data retrieval | [Software](/software/) |
 | relaton-models | UML model definitions and schemas | [GitHub](https://github.com/relaton/relaton-models) |
 
@@ -126,13 +126,13 @@ The code lives across multiple repositories in the [Relaton GitHub organization]
 
 ## History
 
-- Initial release as part of the Metanorma ecosystem
-- Separation into standalone gem architecture
-- Addition of flavor gems (ISO, IEC, IETF, IEEE, ITU, NIST, BIPM, etc.)
-- Integration with IETF for RFC bibliographic data
-- Integration with BIPM for SI Brochure and Metrologia references
-- Addition of DOI (Crossref) and ISBN (OpenLibrary) support
-- Formalization of relaton-models with UML and RelaxNG schemas
-- Continued expansion of supported organizations (CCSDS, IANA, XSF, etc.)
+- **2018** — Initial release as part of the [Metanorma](https://www.metanorma.org) ecosystem
+- **2019** — Separated into standalone gem architecture with `relaton`, `relaton-bib`, and per-SDO flavor gems
+- **2020–2021** — Expanded flavor gems: ISO, IEC, IETF, IEEE, ITU, NIST, BIPM, 3GPP, OGC, and more
+- **2022** — [DOI auto-fetch via Crossref](/blog/2022-12-28-relaton-doi.html); relaton-models formalized with UML and RelaxNG schemas
+- **2023** — [NIST support updated](/blog/2023-08-23-nist-cswp-pubid.html) for new PubID scheme; IETF integration for RFC bibliographic data
+- **2024** — [ISBN auto-fetch via OpenLibrary](/blog/2024-01-19-relaton-isbn.html); BIPM integration for SI Brochure and Metrologia references
+- **2025** — Continued expansion: CCSDS, IANA, XSF, Plateau; relaton-render for formatted citations
+- **2026** — [Relaton.org redesigned](/blog/2026-06-08-site-redesign.html) as a comprehensive documentation site
 
 </div>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Relaton",
+  "short_name": "Relaton",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
+  "theme_color": "#1F6CF1",
   "background_color": "#ffffff",
   "display": "standalone"
 }


### PR DESCRIPTION
## Summary

DRY cleanup across the design system, data layer, and component architecture. Single source of truth for brand colors, gem examples, and search/filter UI.

### Design system
- Replace 36 hardcoded `#1F6CF1` with `var(--vp-c-brand-1)` across 8 components
- Add CSS variables: `--c-brand-border`, `--c-brand-border-strong`, `--c-accent`, `--c-success`
- Brand color now defined once in `custom.css` — change it in one place, site updates everywhere

### Shared component
- Extract `GridControls.vue` from `FlavorGrid` and `SoftwareGrid` — single source of truth for search input + filter tabs markup and styles

### Data-driven content
- Add `sampleDocId` to every gem in software data — each Quick Start shows an organization-relevant example instead of wrong auto-generated code
- Add `quickStartOverride` for non-standard gems: CLI shows shell commands, relaton-render shows rendering, relaton-bib shows model construction
- Quick Start code template lives in one place in SoftwarePage, driven by data

### About page
- Fix `#1F6CF0` → `#1F6CF1` typo in logo color
- Rewrite logo description with 天圓地方 philosophy (circles and squares, heaven and earth)
- Wire ecosystem table to `/software/` pages instead of raw GitHub URLs
- Flesh out History section with dates and blog post links

### Other fixes
- Fix webmanifest: name ("MyWebSite" → "Relaton"), theme_color
- Add `twitter:card` and `twitter:site` meta tags
- Add copy feedback ("Copied!") to hero code panel
- Add `prefers-reduced-motion` for org marquee