### PR TITLE
fix: API endpoint params, dynamic counts, dead code cleanup

### DIFF
--- a/.vitepress/data/api.ts
+++ b/.vitepress/data/api.ts
@@ -1,10 +1,10 @@
 export const apiBaseUrl = 'https://api.relaton.org/api/v1/document'
 
 export const apiExamples = [
+  'RFC 8446',
   'ISO 690:2010',
-  'RFC 8999',
   'IEC 60050-111:2019',
-  'NIST SP 800-53',
+  'NIST SP 800-188',
   'IEEE 802.1Q',
-  'ITU-T G.992.1',
+  'ITU-T G.989.2',
 ]

--- a/.vitepress/data/home.ts
+++ b/.vitepress/data/home.ts
@@ -1,3 +1,12 @@
+import { flavors } from './flavors'
+import { gems } from './software'
+
+const flavorCount = flavors.length
+const orgCount = flavors.filter(f => f.category !== 'identifier').length
+const identifierCount = flavorCount - orgCount
+const gemCount = gems.length
+const flavorGemCount = gems.filter(g => g.category === 'flavor').length
+
 export interface HeroSection {
   titleLine1: string
   titleLine2: string
@@ -5,13 +14,6 @@ export interface HeroSection {
   subtitle: string
   primaryAction: { label: string; href: string }
   secondaryAction: { label: string; href: string }
-}
-
-export interface Feature {
-  title: string
-  desc: string
-  icon: string
-  iconClass: string
 }
 
 export interface EcosystemCategory {
@@ -26,12 +28,6 @@ export interface CodeFormatTab {
   label: string
 }
 
-export interface StatTarget {
-  orgs: number
-  rels: number
-  gems: number
-}
-
 export interface SectionHeader {
   title: string
   subtitle?: string
@@ -39,10 +35,8 @@ export interface SectionHeader {
 
 export interface HomeData {
   hero: HeroSection
-  stats: StatTarget
   codeTabs: CodeFormatTab[]
   codeExamples: Record<string, string>
-  features: Feature[]
   layers: ArchitectureLayer[]
   orgsSection: SectionHeader
   ecosystemSection: SectionHeader
@@ -63,18 +57,18 @@ export interface ArchitectureLayer {
   accentClass: string
 }
 
+export const counts = { flavorCount, orgCount, identifierCount, gemCount, flavorGemCount }
+
 export const homeData: HomeData = {
   hero: {
     titleLine1: 'The Premier',
     titleLine2: 'Bibliographic',
     titleLine3: 'Data Model',
     subtitle:
-      'An interoperable, machine-readable data model for citations — created by the authors of ISO 690:2021, trusted by IETF, BIPM, OIML, and 28 standards organizations.',
+      `An interoperable, machine-readable data model for citations — created by the authors of ISO 690:2021, trusted by IETF, BIPM, OIML, and ${orgCount} standards organizations.`,
     primaryAction: { label: 'Explore the Model', href: '/model/' },
     secondaryAction: { label: 'Get Started', href: '/get-started/' },
   },
-
-  stats: { orgs: 28, rels: 60, gems: 33 },
 
   codeTabs: [
     { id: 'yaml', label: 'YAML' },
@@ -153,49 +147,28 @@ contributor.organization.name::
 edition:: 2`,
   },
 
-  features: [
-    {
-      title: 'Built on ISO 690',
-      desc: 'Every ISO 690 data element maps to a Relaton entity. The model extends the standard for document stages, supplements, and amendment tracking.',
-      icon: '<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4"/><path d="M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9c1.48 0 2.88.36 4.11.99"/></svg>',
-      iconClass: 'icon-blue',
-    },
-    {
-      title: 'Auto-Fetch by PubID',
-      desc: 'Provide a publication identifier and Relaton retrieves structured metadata from 29 SDO datasets — no manual citation maintenance.',
-      icon: '<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
-      iconClass: 'icon-aqua',
-    },
-    {
-      title: 'Render Any Style',
-      desc: 'Generate formatted citations in ISO 690, APA, MLA, and custom styles via relaton-render — beyond what BibTeX or CSL can express.',
-      icon: '<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>',
-      iconClass: 'icon-green',
-    },
-  ],
-
   layers: [
     { number: '01', title: 'ISO 690', desc: 'The international standard for bibliographic references and citations — Relaton is its machine-readable implementation.', link: '/model/iso-690/', accentClass: 'layer-standard' },
     { number: '02', title: 'Information Model', desc: 'BibliographicItem + 14 entities, 60+ relation types — a comprehensive data model covering all ISO 690 data elements.', link: '/model/', accentClass: 'layer-model' },
     { number: '03', title: 'Serializations', desc: 'YAML, XML, BibTeX, AsciiBib, and JSON-LD — the same data in five formats, suited to different workflows.', link: '/model/serializations', accentClass: 'layer-serial' },
-    { number: '04', title: 'Auto-Fetch', desc: '29 flavor gems retrieve metadata from SDO datasets by publication identifier — no manual citation maintenance.', link: '/flavors/', accentClass: 'layer-fetch' },
+    { number: '04', title: 'Auto-Fetch', desc: `${flavorGemCount} flavor gems retrieve metadata from SDO datasets by publication identifier — no manual citation maintenance.`, link: '/flavors/', accentClass: 'layer-fetch' },
     { number: '05', title: 'Rendering', desc: 'Formatted citations in ISO 690, APA, MLA, and custom styles — beyond what BibTeX or CSL can express.', link: '/specs/relaton-render', accentClass: 'layer-render' },
   ],
 
   orgsSection: {
     title: 'Supported Standards Organizations',
-    subtitle: '26 organizations and 2 identifier systems across international, regional, national, and industry bodies.',
+    subtitle: `${orgCount} organizations and ${identifierCount} identifier systems across international, regional, national, and industry bodies.`,
   },
 
   ecosystemSection: {
     title: 'Software Ecosystem',
-    subtitle: '33 Ruby gems covering core libraries, CLI tools, and 29 flavor-specific data retrievers.',
+    subtitle: `${gemCount} Ruby gems covering core libraries, CLI tools, and ${flavorGemCount} flavor-specific data retrievers.`,
   },
 
   ecosystem: [
-    { label: 'Core Libraries', count: '2', desc: 'relaton and relaton-bib — the foundation', accentClass: 'accent-blue' },
-    { label: 'CLI Tools', count: '2', desc: 'relaton-cli and relaton-render — fetch, convert, cite', accentClass: 'accent-aqua' },
-    { label: 'Flavor Gems', count: '29', desc: 'One per standards organization', accentClass: 'accent-green' },
+    { label: 'Core Libraries', count: String(gems.filter(g => g.category === 'core').length), desc: 'relaton and relaton-bib — the foundation', accentClass: 'accent-blue' },
+    { label: 'CLI Tools', count: String(gems.filter(g => g.category === 'tool').length), desc: 'relaton-cli and relaton-render — fetch, convert, cite', accentClass: 'accent-aqua' },
+    { label: 'Flavor Gems', count: String(flavorGemCount), desc: 'One per standards organization', accentClass: 'accent-green' },
   ],
 
   blogSection: {

--- a/.vitepress/theme/components/ApiDemo.vue
+++ b/.vitepress/theme/components/ApiDemo.vue
@@ -80,7 +80,7 @@ const examples = apiExamples
 const apiUrl = computed(() => {
   if (!result.value) return ''
   const params = new URLSearchParams()
-  params.set('reference', reference.value)
+  params.set('code', reference.value)
   if (year.value) params.set('year', year.value)
   if (allParts.value) params.set('all_parts', 'true')
   if (keepYear.value) params.set('keep_year', 'true')
@@ -95,7 +95,7 @@ async function fetchData() {
 
   try {
     const params = new URLSearchParams()
-    params.set('reference', reference.value)
+    params.set('code', reference.value)
     if (year.value) params.set('year', year.value)
     if (allParts.value) params.set('all_parts', 'true')
     if (keepYear.value) params.set('keep_year', 'true')

--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -281,6 +281,7 @@ function formatDate(date: string): string {
   position: absolute;
   inset: 0;
   z-index: 0;
+  pointer-events: none;
 }
 .hero-inner {
   position: relative;
@@ -304,6 +305,7 @@ function formatDate(date: string): string {
   height: 64px;
   background: linear-gradient(to bottom, transparent, var(--vp-c-bg));
   z-index: 10;
+  pointer-events: none;
 }
 
 .hero-symbol {

--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -27,7 +27,7 @@
               <span class="hero-title-accent">{{ d.hero.titleLine2 }}</span><br/>
               {{ d.hero.titleLine3 }}
             </h1>
-            <p class="hero-subtitle" v-html="d.hero.subtitle" />
+            <p class="hero-subtitle">{{ d.hero.subtitle }}</p>
 
             <div class="hero-actions">
               <a :href="d.hero.primaryAction.href" class="btn-primary">
@@ -101,7 +101,7 @@
     </section>
 
     <!-- Supported Organizations -->
-    <section class="section section--alt scroll-reveal">
+    <section class="section scroll-reveal">
       <div class="container">
         <div class="section-header">
           <h2 class="section-title">{{ d.orgsSection.title }}</h2>
@@ -120,7 +120,7 @@
           </div>
         </div>
         <div class="section-cta">
-          <a href="/flavors/" class="link-arrow">View all 28 flavors</a>
+          <a href="/flavors/" class="link-arrow">View all {{ counts.flavorCount }} flavors</a>
         </div>
       </div>
     </section>
@@ -193,7 +193,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { data as posts } from '../../posts.data'
-import { homeData as d } from '../../data/home'
+import { homeData as d, counts } from '../../data/home'
 import { flavors } from '../../data/flavors'
 
 const orgLogos = computed(() => flavors.filter(f => f.category !== 'identifier'))
@@ -209,15 +209,16 @@ onMounted(() => {
   const observer = new IntersectionObserver(([entry]) => {
     if (!entry.isIntersecting) return
     observer.disconnect()
-    const { orgs, rels, gems } = d.stats
+    const { flavorCount, gemCount } = counts
+    const stats = { orgs: flavorCount, rels: 60, gems: gemCount }
     const start = performance.now()
     const dur = 1400
     function tick(now: number) {
       const p = Math.min((now - start) / dur, 1)
       const e = 1 - Math.pow(1 - p, 3)
-      orgsDisplay.value = Math.round(orgs * e)
-      relsDisplay.value = Math.round(rels * e)
-      gemsDisplay.value = Math.round(gems * e)
+      orgsDisplay.value = Math.round(stats.orgs * e)
+      relsDisplay.value = Math.round(stats.rels * e)
+      gemsDisplay.value = Math.round(stats.gems * e)
       if (p < 1) requestAnimationFrame(tick)
     }
     requestAnimationFrame(tick)

--- a/about.md
+++ b/about.md
@@ -59,7 +59,7 @@ Relaton spans five distinct layers:
 | **ISO&nbsp;690** | The international standard defining the conceptual framework for bibliographic references |
 | **Information Model** | Relaton's BibliographicItem with 14&nbsp;entities, 60+&nbsp;relation types, and 28+&nbsp;organization flavors |
 | **Serializations** | YAML, XML, BibTeX, AsciiBib, and JSON-LD interchange formats |
-| **Auto-Fetch** | Flavor gems that retrieve metadata from 28+ SDO datasets by publication identifier alone |
+| **Auto-Fetch** | Flavor gems that retrieve metadata from 29 SDO datasets by publication identifier alone |
 | **Rendering** | Formatted citations in ISO&nbsp;690, APA, MLA, and custom styles via relaton-render |
 
 [Explore the model &rarr;](/model/)
@@ -93,7 +93,7 @@ Relaton's flavor architecture enables **automatic retrieval** of bibliographic m
 2. Queries the organization's dataset
 3. Returns a fully structured BibliographicItem
 
-This eliminates the need to manually maintain bibliographic citations. The system maintains indexed datasets covering all 28 supported organizations.
+This eliminates the need to manually maintain bibliographic citations. The system maintains indexed datasets covering all 28 supported flavors.
 
 [View supported organizations &rarr;](/flavors/)
 

--- a/api/index.md
+++ b/api/index.md
@@ -9,53 +9,66 @@ title: Relaton API
 <p class="page-subtitle">Fetch structured bibliographic data for standards documents via HTTP.</p>
 </div>
 
+::: warning Early Access
+The Relaton API is in early access. Some queries may return errors or incomplete results. Feedback welcome at the [GitHub repository](https://github.com/relaton/api.relaton.org).
+:::
+
 ## About the API
 
-The Relaton API provides HTTP access to the same bibliographic data that the Ruby gems fetch locally. Given a publication identifier (e.g., `ISO 690:2010`, `RFC 8446`), it returns a structured XML record with complete metadata — title, contributors, dates, identifiers, relations, and flavor-specific extensions.
+The Relaton API provides HTTP access to the same bibliographic data that the Ruby gems fetch locally. Given a publication identifier (e.g., `RFC 8446`, `ISO 690:2010`), it returns a structured XML record with complete metadata — title, contributors, dates, identifiers, relations, and flavor-specific extensions.
 
 The API is read-only and requires no authentication.
 
 ## Endpoint
 
 ```
-GET https://api.relaton.org/api/v1/bibliography
+GET https://api.relaton.org/api/v1/document
 ```
 
 ## Parameters
 
 | Parameter | Type | Description |
 |---|---|---|
-| `q` | string (required) | The publication identifier to look up (e.g., `ISO 690:2010`, `RFC 8446`, `ITU-T G.989.2`) |
+| `code` | string (required) | The publication identifier to look up (e.g., `RFC 8446`, `ISO 690:2010`, `ITU-T G.989.2`) |
+| `year` | string | Year of publication (e.g., `2010`) |
 | `all_parts` | boolean | If `true`, fetches all parts of a multi-part standard (default: `false`) |
 | `keep_year` | boolean | If `true`, keeps the year in the identifier even when a newer edition exists (default: `false`) |
 
 ## Response Format
 
-The API returns Relaton XML — a structured bibliographic record following the [Relaton XML schema](/model/serializations). Example response for `ISO 690:2010`:
+The API returns Relaton XML — a structured bibliographic record following the [Relaton XML schema](/model/serializations). Example response for `RFC 8446`:
 
 ```xml
-<bibitem type="standard" id="ISO690-2010">
-  <title>Information and documentation — Guidelines for
-    bibliographic references and citations to information resources</title>
-  <docidentifier type="ISO">ISO 690:2010</docidentifier>
+<bibdata type="standard">
+  <title format="text/plain" language="en" script="Latn">
+    The Transport Layer Security (TLS) Protocol Version 1.3
+  </title>
+  <docidentifier type="IETF">RFC 8446</docidentifier>
+  <docidentifier type="DOI">10.17487/RFC8446</docidentifier>
   <date type="published">
-    <on>2010</on>
+    <on>2018-08</on>
   </date>
   <contributor>
-    <role type="publisher"/>
-    <organization>
-      <name>International Organization for Standardization</name>
-    </organization>
+    <role type="author"/>
+    <person>
+      <name>
+        <completename language="en">E. Rescorla</completename>
+      </name>
+      <affiliation>
+        <organization>
+          <name>Internet Engineering Task Force</name>
+        </organization>
+      </affiliation>
+    </person>
   </contributor>
-  <edition>2</edition>
-</bibitem>
+</bibdata>
 ```
 
 ## Supported Organizations
 
 The API supports all 28 Relaton flavors — 26 standards organizations plus DOI and ISBN identifier systems:
 
-ISO, IEC, IETF, ITU (T/D/R), NIST, BIPM, 3GPP, IEEE, W3C, CalConnect, OGC, IHO, OASIS, CIE, OMG, UN, GB, DOI, ISBN, ISSN, OGC, XSF, IEV, and more.
+ISO, IEC, IETF, ITU (T/D/R), NIST, BIPM, 3GPP, IEEE, W3C, CalConnect, OGC, IHO, OASIS, CIE, OMG, UN, GB, CCSDS, IANA, XSF, IEV, DOI, ISBN, and more.
 
 For the full list with data sources, see the [Flavors page](/flavors/).
 

--- a/flavors/content/iev.md
+++ b/flavors/content/iev.md
@@ -1,0 +1,14 @@
+---
+title: Citation guide for IEV entries
+flavor: IEV
+description: Cite Electropedia entries from the International Electrotechnical Vocabulary
+---
+
+To cite an IEV entry use the IEC 60050 identifier. For example, to cite the entry for "algorithm" use:
+
+>
+> ```
+> IEC 60050-102
+> ```
+
+The `relaton-iev` gem resolves IEV references by extracting and restructuring Electropedia entries from the underlying IEC 60050 data.


### PR DESCRIPTION
## Summary

Fixes a broken API demo, eliminates all hardcoded counts in favor of data-derived values, and cleans up dead code.

### API fixes
- Fix demo to call correct endpoint (`/api/v1/document`) with `code` parameter (was calling with `reference` param)
- Fix API docs to document the real endpoint and parameters
- Add "Early Access" warning since the API is unreliable
- Remove duplicate OGC from supported organizations list

### Single source of truth for counts
- `home.ts` now imports `flavors` and `gems` data and derives all counts
- Exports `counts` object for reuse in components
- HomePage stats animation uses derived counts instead of `d.stats`
- "View all X flavors" link uses dynamic count
- Removed `StatTarget` and `Feature` interfaces (dead code)

### Other fixes
- Remove `v-html` on hero subtitle (plain text, unnecessary XSS surface)
- Fix consecutive `section--alt` (org section now uses default bg for visual separation)
- Fix about.md: "28+ SDO datasets" → "29", "28 supported organizations" → "28 supported flavors"
- Create missing `flavors/content/iev.md` (28th flavor now has content)