### PR TITLE
fix: mobile scroll blocked by VPHome overflow-x

### DIFF
--- a/.vitepress/theme/components/HomePage.vue
+++ b/.vitepress/theme/components/HomePage.vue
@@ -271,8 +271,7 @@ function formatDate(date: string): string {
 /* ── Hero ─────────────────────────────────────────────── */
 .hero {
   position: relative;
-  overflow-x: hidden;
-  overflow-y: clip;
+  overflow: clip;
   background: linear-gradient(135deg, #1C2126 0%, #152035 40%, #0E2A3A 70%, #0B1F2D 100%);
 }
 .dark .hero {

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -306,7 +306,7 @@ body {
 
 /* Home layout */
 .VPHome {
-  overflow-x: hidden;
+  overflow-x: clip;
   margin-bottom: 0 !important;
 }
 


### PR DESCRIPTION
The root cause: `overflow-x: hidden` on `.VPHome` implicitly computes to `overflow-y: auto` per CSS spec (can't mix visible with non-visible overflow). This creates a vertical scroll container that traps the first touch on mobile.

Fix: use `overflow-x: clip` which clips overflow without creating a scroll container.