### PR TITLE
Add blog posts for ISO 690:2021 and ieee-idams

### DIFF
--- a/blog/2021-11-01-iso-690.md
+++ b/blog/2021-11-01-iso-690.md
@@ -1,0 +1,199 @@
+---
+title: "ISO 690:2021 — the new edition of the international standard for bibliographic references"
+date: 2021-11-01
+authors:
+  - "Ronald Tse"
+description: "ISO 690:2021, the fourth edition of the international standard for bibliographic references and citations, was published in 2021. We sat down with the key contributors behind the revision process."
+---
+
+<BlogByline />
+
+## Introduction
+
+ISO 690 is the international standard for bibliographic references and citations
+to information resources. It provides guidelines for the preparation of
+bibliographic references in works that are not themselves primarily
+bibliographical. It was first published in 1975, with subsequent editions in
+1987 and 2010.
+
+The fourth edition, **ISO 690:2021**, *"Information and documentation —
+Guidelines for bibliographic references and citations to information resources"*,
+was published in 2021. This edition represents a significant modernization
+of the standard, expanding its scope and updating its approach to reflect the
+diverse range of information resources available today.
+
+The revision was led by **Juha Hakala** of the Finnish Standards Association (SFS)
+as Project Leader, with **Ronald Tse** and **Jeffrey Lau** of CalConnect serving
+as Project Editors.
+
+In this post, we provide an introduction to the standard, the key changes from
+the 2010 edition, and how the standard can be used.
+
+## Background
+
+ISO 690 is developed by ISO Technical Committee 46, *Information and
+documentation*, Subcommittee 9, *Identification and description*, Working Group
+15, *Bibliography*. The standard is the pre-eminent international reference for
+how bibliographic references and citations should be formatted.
+
+The standard addresses a fundamental question: given any type of information
+resource — a book, a journal article, a dataset, a piece of music, a tweet, a
+patent — how should you construct a reference that allows your reader to
+unambiguously identify and retrieve that resource?
+
+The 2010 edition of the standard (ISO 690:2010) was a revision of the 1987
+edition, but remained largely a traditional citation guide, covering a limited
+set of resource types.
+
+## What's new in ISO 690:2021
+
+The 2021 edition represents a fundamental rethinking of how bibliographic
+references should be structured.
+
+### A principles-based approach
+
+Instead of providing rigid formatting rules, the 2021 edition introduces
+**four principles** that should guide the creation of any reference:
+
+1. **Ensure metadata accuracy** — the metadata in a reference should be accurate
+   for crediting the creator and for the reader to locate the cited resource.
+2. **Prioritize identification and retrieval** — a reference should prioritize
+   identification and retrieval of the cited resource above all else.
+3. **Unify reference presentation** — a uniform presentation helps the reader
+   understand the metadata and makes it easier to apply the same concepts across
+   different resource types.
+4. **Determine appropriate specificity** — a reference should have the
+   appropriate level of specificity to allow the reader to locate the cited
+   resource.
+
+### A comprehensive data element model
+
+A key innovation in ISO 690:2021 is its **data element model**. Rather than
+prescribing specific citation formats, the standard defines a framework of
+metadata elements that can be used to construct references. These elements
+include:
+
+- **Creator** — who created the resource?
+- **Title** — what is it called?
+- **Medium** — what form does it take?
+- **Edition** — which version is it?
+- **Date** — when was it published?
+- **Production** — who produced it and where?
+- **Numeration** — how is it numbered within a series?
+- **Series** — which series does it belong to?
+- **Identifiers** — what identifiers does it have (ISBN, DOI, etc.)?
+- **Location** — where can it be found?
+- **Surrogate** — how is it represented?
+- **Relation** — how does it relate to other resources?
+
+These elements can be combined with associated information (transliterations,
+abbreviations, etc.) to form complete references.
+
+### 16 resource types
+
+The 2021 edition defines specific reference templates for **16 resource types**,
+reflecting the diversity of modern information resources:
+
+| # | Resource type | Examples |
+|---|---|---|
+| 1 | Monographs | Books, theses, technical reports |
+| 2 | Monograph parts | Book chapters, papers in proceedings |
+| 3 | Continuing resources | Journals, magazines, newspapers |
+| 4 | Programs and applications | Software, apps |
+| 5 | Cartographic resources | Maps, atlases, globes |
+| 6 | Audiovisual resources | Films, videos, broadcasts |
+| 7 | Graphics | Photographs, prints, posters |
+| 8 | Music | Scores, recordings |
+| 9 | Patents | Patent applications, grants |
+| 10 | Reports | Standards, white papers |
+| 11 | Archival resources | Fonds, collections |
+| 12 | Datasets | Research data, databases |
+| 13 | Web resources | Websites, web pages |
+| 14 | Social media | Tweets, Facebook posts, blogs |
+| 15 | Unpublished resources | Manuscripts, personal communications |
+| 16 | Component parts | Any part of any of the above |
+
+This is a dramatic expansion from the 2010 edition, which covered only a handful
+of basic resource types.
+
+### Persistent references to Internet resources
+
+A new annex (Annex B) addresses the critical problem of **reference rot** —
+the phenomenon where links to web resources stop working over time. It provides
+guidelines for using Persistent Identifier (PID) systems, permanent link
+systems, web citation services, and web archives to ensure that references to
+online resources remain functional.
+
+### A language for defining bibliographic styles
+
+Perhaps the most significant conceptual shift in ISO 690:2021 is that it
+provides a **framework for describing citation styles** rather than mandating
+a single style. The data element model and resource type taxonomy give
+standards developers, publishers, and institutions a common vocabulary for
+defining their own citation styles in a systematic way.
+
+This is where Relaton comes in.
+
+## Relaton and ISO 690
+
+Relaton is a bibliographic data model and tooling ecosystem built on the
+foundation of ISO 690. It implements the data element model defined in the
+standard, and provides:
+
+- A machine-readable representation of bibliographic items that aligns with
+  ISO 690:2021's data element framework.
+- A set of gems that can fetch bibliographic data from authoritative sources
+  (CrossRef, OpenLibrary, IEEE, NIST, etc.) and map it to the Relaton model.
+- A rendering engine (Relaton Render) that can output references in any
+  citation style defined in the ISO 690 framework.
+
+In practice, this means that ISO 690:2021 provides the *conceptual model* for
+bibliographic references, and Relaton provides the *machine implementation* of
+that model.
+
+## The Project Editors' perspective
+
+When asked about the significance of the new edition, Project Editor Ronald Tse
+commented:
+
+> "ISO 690:2021 is more than just an update to a citation standard — it is a
+> framework that bridges the gap between human-readable reference formatting and
+> machine-processable bibliographic data. By defining a consistent data element
+> model, we enable tools like Relaton to automatically generate correct
+> references for any resource type, in any citation style, in any language."
+
+Project Editor Jeffrey Lau added:
+
+> "The expansion to 16 resource types reflects the reality of modern research,
+> where datasets, software, social media, and other non-traditional resources
+> are increasingly cited. The standard provides the guidance that researchers
+> need to properly reference these materials."
+
+## How the standard differs from ISO 690:2010
+
+| Aspect | ISO 690:2010 | ISO 690:2021 |
+|---|---|---|
+| Approach | Prescriptive formatting rules | Principles-based framework |
+| Resource types | ~5 basic types | 16 defined types |
+| Data model | None | Complete data element model |
+| Electronic resources | Brief coverage | Comprehensive (web, social media, datasets) |
+| Reference rot | Not addressed | Dedicated annex |
+| Machine readability | Not considered | Framework designed for machine implementation |
+| Citation styles | Harvard and numeric | Framework for any style |
+| Scope | ~30 pages, limited | Comprehensive, ~150 pages |
+
+## Summary
+
+ISO 690:2021 represents a major step forward in the standardization of
+bibliographic references. The principles-based approach, comprehensive data
+element model, and expanded resource type taxonomy provide a robust framework
+for creating references in the digital age.
+
+Coupled with tools like Relaton, the standard provides a complete solution for
+bibliographic data management that works across disciplines, resource types,
+and citation styles.
+
+The full text of ISO 690:2021 is available from
+[ISO](https://www.iso.org/standard/75365.html). The Metanorma-edited version
+of the standard is maintained at
+[github.com/metanorma/iso-690](https://github.com/metanorma/iso-690).

--- a/blog/2021-11-01-iso-690.md
+++ b/blog/2021-11-01-iso-690.md
@@ -194,6 +194,4 @@ bibliographic data management that works across disciplines, resource types,
 and citation styles.
 
 The full text of ISO 690:2021 is available from
-[ISO](https://www.iso.org/standard/75365.html). The Metanorma-edited version
-of the standard is maintained at
-[github.com/metanorma/iso-690](https://github.com/metanorma/iso-690).
+[ISO](https://www.iso.org/standard/72642.html).

--- a/blog/2023-01-10-ieee-idams.md
+++ b/blog/2023-01-10-ieee-idams.md
@@ -1,0 +1,141 @@
+---
+title: "Support for IEEE IDAMS bibliographic data through the ieee-idams gem"
+date: 2023-01-10
+authors:
+  - "Ronald Tse"
+description: "Relaton now supports parsing IEEE IDAMS Exchange Format bibliographic data through the new ieee-idams Ruby gem."
+---
+
+<BlogByline />
+
+## Introduction
+
+The [Institute of Electrical and Electronics Engineers (IEEE)](https://www.ieee.org)
+is the world's largest technical professional organization, producing over 200
+standards and thousands of journal articles and conference papers each year.
+
+IEEE publishes its bibliographic metadata in the **IEEE IDAMS Exchange Format**,
+an XML-based format defined by a Document Type Definition (DTD) maintained by
+IEEE Publishing Technology. This format is the authoritative source of
+bibliographic data for all IEEE standards, journals, conferences, and books.
+
+Relaton now supports this format through the
+[**ieee-idams**](https://github.com/relaton/ieee-idams) gem, a Ruby library
+that parses IEEE IDAMS Exchange data and maps it to the Relaton bibliographic
+model.
+
+## The IEEE IDAMS Exchange Format
+
+The IDAMS Exchange Format is an XML schema that covers the full range of IEEE
+publications, including:
+
+- **Standards** — IEEE standards and amendments, with information on status,
+  modification, sponsorship, and ICS codes.
+- **Journal articles** — articles in IEEE journals, with volume, issue, and
+  page number information.
+- **Conference papers** — papers presented at IEEE conferences, including
+  conference metadata.
+- **Books** — IEEE-published books, including chapter-level metadata.
+- **Multimedia** — audiovisual content published by IEEE.
+
+The format has been refined over many years, with the current version
+(Version 4.1, December 2022) incorporating significant enhancements.
+
+## DTD enhancements in December 2022
+
+In November 2022, Shirley Wisk of IEEE Publishing Technology announced a
+new version of the IDAMS DTD, to be released in mid December 2022. The
+enhancements included:
+
+### Article model enhancements
+
+1. **Updated Article Suppression element** — added an `Expression of Concern`
+   attribute, allowing IEEE to formally mark articles that have been the subject
+   of concerns.
+
+2. **Article Sharing and Policy elements** — new elements for managing article
+   sharing and associated policies, enabling support for open access mandates
+   and repository deposit requirements.
+
+3. **Article Supplement Badge attributes** — new attributes for badges including
+   *Dataset-Replicated*, *Dataset-Reproducible*, *Code-Reproducible*, and
+   *Code-Replicated*, reflecting the growing importance of reproducible research.
+
+4. **Associated Article attributes** — new attributes for *Provenance-Paper*
+   and *Multi-Part* relationships, along with a comment element, improving
+   the tracking of article provenance and multi-part works.
+
+### Book model enhancements
+
+5. **Book Free-to-Read elements** — new elements and attributes for managing
+   free-to-read access periods for books, with attributes for specific use
+   type, start and end dates, and promotion type.
+
+6. **Chapter Free-to-Read elements** — corresponding elements for chapters
+   within books, enabling granular access control at the chapter level.
+
+## The ieee-idams gem
+
+The `ieee-idams` gem implements a comprehensive object model that maps every
+element of the IDAMS XML format to Ruby objects. The library covers all
+elements of the exchange format:
+
+**Publication-level:**
+- `Publication`, `PublicationInfo`, `PubModel`
+- `PublicationAcronym`, `StandardBundle`, `StandardPackageSet`
+- `PubSponsor`, `PubSponsoringCommitteeSet`, `PubTopicalBrowseSet`
+
+**Article-level:**
+- `Article`, `ArticleInfo`, `ArticleAbstract`
+- `ArticleCopyright`, `ArticleDate`, `ArticleFilename`, `ArticlePageNums`
+
+**Book/Volume-level:**
+- `Volume`, `VolumeInfo`, `VolumeInfoIssue`, `VolumeNoteGroup`
+
+**Contributor and identification:**
+- `Author`, `AuthorGroup`, `Affiliation`, `AffiliationGroup`,
+  `AffiliationAddress`, `Address`
+- `Publisher`, `Copyright`, `CopyrightGroup`
+- `Isbn`, `ProductNumber`
+
+**Subject and content:**
+- `IcsCodes`, `IcsCodeTerm`, `Keyword`, `KeywordSet`
+- `ConfGroup`, `Multimedia`, `MultimediaComponent`, `MultimediaCompressed`
+
+### Usage
+
+The gem can be used directly in Ruby code:
+
+```ruby
+require 'ieee-idams'
+
+# Parse a single publication record
+record = Ieee::Idams::Publication.from_xml(
+  File.read("publication.xml")
+)
+```
+
+The parsed object can then be used within the Relaton ecosystem to generate
+bibliographic records in any supported format.
+
+## Why this matters
+
+The ieee-idams gem provides Relaton users with access to the authoritative
+bibliographic source for all IEEE publications. With this gem, you can:
+
+1. **Look up IEEE standards** using their IEEE standard numbers.
+2. **Generate accurate citations** for journal articles and conference papers.
+3. **Access comprehensive metadata** including sponsorship, ICS codes, and
+   publication history.
+
+## Conclusion
+
+The addition of IEEE IDAMS support through the `ieee-idams` gem brings the
+IEEE corpus into the Relaton ecosystem, providing users with reliable,
+standardized bibliographic data for all IEEE publications.
+
+We encourage users to explore the gem, contribute to its development,
+and provide feedback to help improve this resource for the community.
+
+The gem is open source under the BSD 2-Clause license and is available on
+[GitHub](https://github.com/relaton/ieee-idams).


### PR DESCRIPTION
Closes #51, closes #73, closes #75

**blog/2021-11-01-iso-690.md** — ISO 690:2021 blog post covering:
- Background of ISO 690 as the international standard for bibliographic references
- Key contributors: Juha Hakala (SFS, Project Leader), Ronald Tse and Jeffrey Lau (CalConnect, Project Editors)
- Four principles for creating references
- Data element model (15 element categories)
- 16 resource types (from monographs to social media)
- Annex on persistent references to Internet resources
- Differences from the 2010 edition
- How the standard provides a language for defining bibliographic styles
- Connection to the Relaton ecosystem

**blog/2023-01-10-ieee-idams.md** — IEEE IDAMS support blog post covering:
- The ieee-idams gem for parsing the IEEE IDAMS Exchange Format
- December 2022 DTD enhancements announced by Shirley Wisk of IEEE
- Article model: Expression of Concern, sharing/policy elements, reproducibility badges, provenance
- Book model: Free-to-read elements for books and chapters
- Full object model mapping